### PR TITLE
mktemp works differently on OS X

### DIFF
--- a/scripts/latex.sh
+++ b/scripts/latex.sh
@@ -14,7 +14,11 @@ LATEX=$2
 STEM=$3
 
 # Temporary directory
-TMPD=`mktemp -d --tmpdir=$SPD/tmp`
+if [ `uname` == "Darwin" ]; then
+	TMPD=`mktemp -d -t tmp`
+else
+	TMPD=`mktemp -d --tmpdir=$SPD/tmp`
+fi	
 
 # Symbolically link files that are hopefully not modified during process
 ln -s $SPD/preamble.tex $SPD/chapters.tex $SPD/hyperref.cfg \

--- a/tags/latex.sh
+++ b/tags/latex.sh
@@ -10,7 +10,11 @@ STEM=$2
 OLD=${PWD}
 
 # Temporary directory
-TMPD=`mktemp -d --tmpdir=../../tmp`
+if [ `uname` == "Darwin" ]; then
+        TMPD=`mktemp -d -t tmp`      
+else
+        TMPD=`mktemp -d --tmpdir=../../tmp`
+fi
 
 # Symbolically link or copy files to temp dir
 # 	Common for both cases


### PR DESCRIPTION
While trying to instantiate a local copy of the stacks-website, I discovered that `mktemp` works differently on OS X than on Linux. This fixes the `latex.sh` scripts so that `make tags` works on OS X, too.