### PR TITLE
New proof of Lemma 0032

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -2203,126 +2203,121 @@ $$
 \longrightarrow
 \lim_{i \in I} M(x_i)
 $$
-of Lemma \ref{lemma-functorial-limit} is an isomorphism.
+of Lemma~\ref{lemma-functorial-limit} is an isomorphism.
 \end{enumerate}
 \end{lemma}
 
 \begin{proof}
-Consider quadruples $(S, A, x, \{f_s\}_{s \in S})$ with the
-following properties
-\begin{enumerate}
-\item $S$ is a finite set of objects of $\mathcal{I}$,
-\item $A$ is a finite set of arrows of $\mathcal{I}$ such that
-each $a \in A$ is an arrow $a : s(a) \to t(a)$ with $s(a), t(a) \in S$,
-\item $x$ is an object of $\mathcal{I}$, and
-\item $f_s : s \to x$ is a morphism of $\mathcal{I}$ such that
-for all $a \in A$ we have $f_{t(a)} \circ a = f_{s(a)}$.
-\end{enumerate}
-Given such a quadruple $i = (S, A, x, \{f_s\}_{s \in S})$
-we denote $S_i = S$, $A_i = A$, $x_i = x$, and $f_{s, i} = f_s$
-for $s \in S_i$. We also set
-$\tilde S_i = S_i \cup \{x_i\}$ and
-$\tilde A_i = A_i \cup \{f_{s, i}, s \in S_i\}$.
-Let $I$ be the set of all such quadruples.
-We define a relation on $I$ by the rule
-$$
-i \leq i' \Leftrightarrow
-(i = i') \text{ or } (
-\tilde S_i \subset S_{i'} \text{ and } \tilde A_i \subset A_{i'})
-$$
-It is obviously a partial ordering on $I$. Note that if $i \leq i'$,
-then there is a given morphism $\varphi_{ii'} : x_i \to x_{i'}$
-namely $f_{x_i, i'}$ because $x_i \in S_{i'}$.
-Hence we have a system over $I$ in $\mathcal{I}$ by taking
-$(x_i, \varphi_{ii'})$. We claim that this system satisfies all
-the conditions of the lemma.
+As mentioned in the beginning of the section, we may view
+partially ordered sets as categories and systems as functors.
+Throughout the proof, we will freely shift between these two points
+of view.
+We prove the first statement by constructing a category
+$\mathcal{I}_0$, corresponding to a directed set, and a cofinal
+functor $M_0\colon \mathcal{I}_0 \to \mathcal{I}$. Then, by
+Lemma~\ref{lemma-cofinal-filtered}, the colimit of a diagram
+$M\colon \mathcal{I} \to \mathcal{C}$ coincides with the
+colimit of the diagram $M\circ M_0\colon \mathcal{I}_0 \to \mathcal{C}$,
+from which the statement follows. The second stament is dual to the
+first and may be proved by interpreting a limit in $\mathcal{C}$ as
+a colimit in $\mathcal{C}^{opp}$. We omit the details.
 
 \medskip\noindent
-First we show that $I$ is a directed partially ordered set.
-Note that $I$ is nonempty since $(\{x\}, \emptyset, x, \{\text{id}_x\})$
-is a quadruple where $x$ is any object of $\mathcal{I}$, and
-$\mathcal{I}$ is not empty according to
-Definition \ref{definition-directed}.
-Suppose that $i, i' \in I$. Consider the set of objects
-$S = S_i \cup S_{i'} \cup \{x_i, x_{i'}\}$ of $\mathcal{I}$.
-This is a finite set. According to Definition \ref{definition-directed}
-and a simple induction argument there exists an object $x'$ of
-$\mathcal{I}$ such that for each $s \in S$ there is a morphism
-$f'_s : s \to x'$. Consider the set of arrows
-$A = A_i \cup A_{i'} \cup \{f_{s, i}, s \in S_i\}
-\cup \{f_{s, i'}, s \in S_{i'}\}$. This is a finite set of
-arrows whose source and target are elements of $S$.
-According to Definition \ref{definition-directed}
-and a simple induction argument there exists a morphism
-$f : x' \to x$ such that for all $a \in A$ we have
-$$
-f \circ f'_{t(a)} \circ a = f \circ f'_{s(a)}
-$$
-as morphisms into $x$. Hence we see that
-$(S, A, x, \{f \circ f'_s\}_{s \in S})$ is a quadruple which is
-$\geq i$ and $\geq i'$ in the partial ordering defined above.
-This proves $I$ is directed.
+A category $\mathcal{F}$ is called {\em finitely generated} if
+there exists a finite set $F$ of arrows in $\mathcal{F}$, such that
+each arrow in $\mathcal{F}$ may be obtained by composing
+arrows from $F$. In particular, this implies that $\mathcal{F}$ has
+finitely many objects. We start the proof by reducing to the case
+when $\mathcal{I}$ has the property that every finitely generated
+subcategory of $\mathcal{I}$ may be extended to a finitely
+generated subcategory with a unique final object.
 
 \medskip\noindent
-Next, we prove the statement about colimits.
-Let $\mathcal{C}$ be a category.
-Let $M : \mathcal{I} \to \mathcal{C}$ be a functor.
-Denote $(M(x_i), M(\varphi_{ii'}))$ the corresponding system over $I$.
-Below we will write $M_i = M(x_i)$ for clarity.
-Assume $K = \colim_{i \in I} M(x_i)$ exists.
-We will verify that $K$ is also the colimit of the diagram $M$.
-Recall that for every object $x$ of $\mathcal{I}$ the
-quadruple $i_x = (\{x\}, \emptyset, x, \{\text{id}_x\})$ is an
-element of $I$. By definition of a colimit there is a morphism
-$$
-M(x) = M_{i_x} \longrightarrow K
-$$
-Let $\varphi : x \to x'$ be a morphism of $\mathcal{I}$.
-The quadruples $i_x$, $i_{x'}$ and
-$$
-i_{\varphi}
-=
-(\{x, x'\},
-\{\text{id}_x, \text{id}_{x'}, \varphi\},
-x',
-\{\varphi, \text{id}_{x'}\})
-$$
-are elements of $I$. Moreover, $i_x \leq i_{\varphi}$ and
-$i_{x'} \leq i_{\varphi}$. Thus the diagram
+Let $\omega$ denote the directed set of finite ordinals, which
+we view as a filtered category. It is easy to verify that the
+product category $\mathcal{I}\times \omega$ is also filtered,
+and the projection
+$\Pi\colon\mathcal{I}\times \omega \to \mathcal{I}$
+is cofinal.
+
+\medskip\noindent
+Now let $\mathcal{F}$ be any finitely generated
+subcategory of $\mathcal{I}\times \omega$.
+By using the axioms of a filtered category and a simple induction
+argument on a finite set of generators of $\mathcal{F}$,
+we may construct a cocone $(\{f_i\}, i_\infty)$ in $\mathcal{I}$
+for the diagram $\mathcal{F} \to \mathcal{I}$. That is, a morphism
+$f_i\colon i \to i_\infty$ for every object $i$ in $\mathcal{F}$
+such that for each arrow $f\colon i \to i'$ in $\mathcal{F}$
+we have $f_i = f\circ f_{i'}$. We also choose $i_\infty$ such
+that it is not contained in $\mathcal{F}$. This is possible since
+we may always post-compose the arrows $f_i$ with an arrow
+which is the identity on the $\mathcal{I}$-component and
+strictly increasing on the $\omega$-component.
+Now let $\mathcal{F}^+$ denote the category consisting of all
+objects and arrows in $\mathcal{F}$
+together with the object $i_\infty$, the identity
+arrow $\mathrm{id}_{i_\infty}$ and the arrows $f_i$.
+Since there are no arrows from $i_\infty$ in $\mathcal{F}^+$
+to any object of $\mathcal{F}$, the arrow set in $\mathcal{F}^+$
+is closed under composition, so $\mathcal{F}^+$ is indeed
+a category. By construction, it is a finitely
+generated subcategory of $\mathcal{I}$ which has $i_\infty$ as
+unique final object. Since, by  Lemma~\ref{lemma-cofinal-filtered},
+the colimit of  any diagram $M\colon\mathcal{I} \to \mathcal{C}$
+coincides with the colimit of $M\circ\Pi$ , this gives the desired
+reduction.
+
+\medskip\noindent
+The set of all finitely generated subcategories of $\mathcal{I}$
+with a unique final object is naturally ordered by inclusion.
+We take $\mathcal{I}_0$ to be the category corresponding
+to this set. We also have a functor
+$M_0\colon\mathcal{I}_0 \to \mathcal{I}$, which takes an
+arrow $\mathcal{F} \subset \mathcal{F'}$ in
+$\mathcal{I}_0$ to the unique map from the final object of
+$\mathcal{F}$ to the final object of $\mathcal{F}'$.
+Given any two finitely generated subcategories of
+$\mathcal{I}$, the category generated by these two categories is
+also finitely generated. By our assumption on $\mathcal{I}$, it is
+also contained in a finitely generated subcategory of $\mathcal{I}$
+with a unique final object. This shows that $\mathcal{I}_0$ is directed.
+
+\medskip\noindent
+Finally, we verify that $M_0$ is cofinal. Since any
+object of $\mathcal{I}$ is the final object in the subcategory
+consisting of only that object and its identity arrow, the functor
+$M_0$ is surjective on objects. In particular, Condition~(1) of
+Definition~\ref{definition-cofinal-filtered} is satisfied. Given
+a pair $\mathcal{F}_1, \mathcal{F}_2$ in $\mathcal{I}_0$ and
+a map $\varphi\colon M_0(\mathcal{F}_1) \to M_0(\mathcal{F}_2)$ in
+$\mathcal{I}$, we can take $\mathcal{F}_{12}$ to be a finitely
+generated category with a unique final object containg
+$\mathcal{F}_1$, $\mathcal{F}_2$ and the morphism $\varphi$.
+The resulting diagram commutes
 $$
 \xymatrix{
-M(x) = M_{i_x} \ar[r] \ar[dr] &
-M(x') = M_{i_{\varphi}} \ar[d] &
-M(x') = M_{i_{x'}} \ar[l] \ar[dl] \\
-& K &
+& M_0(\mathcal{F}_{12}) & \\
+M_0(\mathcal{F}_{1}) \ar[rr]^\varphi \ar[ru] & & M_0(\mathcal{F}_{2}) \ar[lu]
 }
 $$
-is commutative in $\mathcal{C}$.
-Since the left pointing horizontal arrow is the identity morphism
-on $M(x')$ by our definition of $\varphi_{i_{x'}i_{\varphi}}$
-we see that the morphisms $M(x) \to K$ so defined satisfy
-condition (1) of Definition \ref{definition-colimit}.
-
-\medskip\noindent
-Finally we have to verify condition (2) of Definition \ref{definition-colimit}.
-Suppose that $W$ is an object of $\mathcal{C}$ and suppose that we are
-given morphisms $w_x : M(x) \to W$ such that for all morphisms
-$a$ of $\mathcal{I}$ we have $w_{s(a)} = w_{t(a)} \circ a$.
-In this case, set $w_i = w_{x_i}$ for a quadruple
-$i = (S_i, A_i, x_i, \{f_{s, i}\}_{s \in S_i})$. Note that the
-condition on the maps $w_x$ in particular guarantees that
-$w_{i'} = w_i \circ M(\varphi_{ii'})$ if $i \leq i'$ in $I$.
-Because $K$ is the
-colimit of the system $(M(x_i), M(\varphi_{ii'})$ we obtain a
-unique morphism $K \to W$ compatible with the maps $w_i$
-and the given morphisms $M_i \to K$. This proves the statement about
-colimits of the lemma.
-
-\medskip\noindent
-We omit the proof of the statement about limits.
-(Hint: You can change it into a statement about colimits
-by considering the opposite category of $\mathcal{C}$.)
+since it lives in $\mathcal{F}_{12}$ and $M_0(\mathcal{F}_{12})$ is final in
+this category. Hence also Condition~(2) is satisfied, which concludes
+the proof.
 \end{proof}
+
+\begin{remark}
+Note that a finite directed set $(I, \geq)$ always has a greatest object
+$i_\infty$. Hence any colimit of a system $(M_i, f_{ii'})$ over such a set
+is trivial in the sence that the colimit equals $M_{i_\infty}$. In contrast,
+a colimit indexed by a finite filtered category need not
+be trival. For instace, let $\mathcal{I}$ be the category with a single object
+$i$ and a single non-trivial morphisms $e$ satisfying $e = e \circ e$. The
+colimit of a diagram $M\colon\mathcal{I} \to Sets$ is the image of the
+idempotent $M(e)$. This illustrates that something like the trick of passing
+to $\mathcal{I}\times \omega$ in the proof of
+Lemma~\ref{lemma-directed-category-system} is essential.
+\end{remark}
 
 \begin{lemma}
 \label{lemma-nonempty-limit}


### PR DESCRIPTION
I wrote down a new proof for the lemma about colimits indexed filtered categories as colimits indexed by partially ordered sets. The proof is maybe slightly too long. It could be shortened by doing any of these things:
1. Split the Lemma in two. One which asserts the existence of a cofinal functor I_0 -> I and corollary using a formulation in terms of systems.
2. The definition of cone and cocone could be moved to the section about limits (002D)
3. The definition of finiely generated category could be moved to the section about finite limits a colimits (04AS)
4. The fact that any finite (finitely generated) diagram in a filtered category could be stated as a separate lemma in the section about filtered categories (04AX).
5. The statement that a product of filtered categories is filtered could be stated as a separate lemma.
6. The statement that compositions of cofinial functors are cofinal could be stated as a separate lemma.
