### PR TITLE
Fixed two typos in proof of Tag 07K5 (lemma-unbounded-right-derived).

### DIFF
--- a/derived.tex
+++ b/derived.tex
@@ -8723,7 +8723,7 @@ We are going to use Lemma \ref{lemma-replace-resolution} with the function
 $d : \Ob(\mathcal{A}) \to \{0, 1, 2, \ldots \}$ given by
 $d(A) = \min \{0\} \cup \{i \mid R^iF(A) \not = 0\}$.
 The first assumption of Lemma \ref{lemma-replace-resolution}
-is our assumption (3) and the second assumption of
+is our assumption (1) and the second assumption of
 Lemma \ref{lemma-replace-resolution} follows from the long exact
 cohomology sequence. Hence for every complex $K^\bullet$ there exists a
 quasi-isomorphism $K^\bullet \to L^\bullet$ with $L^n$ right acyclic for $F$.
@@ -8746,7 +8746,7 @@ Using the spectral sequence of Lemma \ref{lemma-two-ss-complex-functor}
 and the assumed vanishing of cohomology (2) we conclude
 that $R^jF(Q^\bullet)$ is zero except possibly for
 $j \in \{i - n - 2, \ldots, i - 1\}$. Hence we see that
-$RF(\sigma_{\geq i - n - 1}L^\bullet) \to RF(\sigma_{\geq i - n - 1}L^\bullet)$
+$RF(\sigma_{\geq i - n - 1}L^\bullet) \to RF(\sigma_{\geq i - n - 1}M^\bullet)$
 induces an isomorphism of cohomology objects in degrees $\geq i$.
 By Proposition \ref{proposition-enough-acyclics} we know that
 $RF(\sigma_{\geq i - n - 1}L^\bullet) = \sigma_{\geq i - n - 1}F(L^\bullet)$


### PR DESCRIPTION
I'm trying out the online edit functionality in GitHub (which is so-so). Anyway, since it is now really easy to browse the stacks project online and one sees file names and line numbers, fixing typos "offline" has also become much simpler.
