### PR TITLE
Minor improvement in section about Serre subcategories

### DIFF
--- a/homology.tex
+++ b/homology.tex
@@ -1833,17 +1833,23 @@ Categories, Lemma \ref{categories-lemma-properties-left-localization}.
 \label{lemma-quotient-by-kernel-exact-functor}
 Let $\mathcal{A}$, $\mathcal{B}$ be abelian categories.
 Let $F : \mathcal{A} \to \mathcal{B}$ be an exact functor.
-Let $\mathcal{C} = \Ker(F)$. Then the induced functor
+Then $\mathcal{C} = \Ker(F)$ if and only if the induced functor
 $\overline{F} : \mathcal{A}/\mathcal{C} \to \mathcal{B}$ is
 faithful.
 \end{lemma}
 
 \begin{proof}
-This is true because the kernel of $\overline{F}$ is zero by
+The ``only if'' direction is true because the kernel of $\overline{F}$ is zero by
 construction. Namely, if $f : X \to Y$ is a morphism in
 $\mathcal{A}/\mathcal{C}$ such that $\overline{F}(f) = 0$, then
 $\overline{F}(\Im(f)) = \Im(\overline{F}(f)) = 0$, hence $\Im(f) = 0$ by the
 assumption on the kernel of $F$. Thus $f = 0$.
+
+For the ``if'' direction, let $X$ be an object of $\mathcal{A}$ such that $F(X)
+= 0$. Then $\overline{F}(\text{id}_X) = \text{id}_{\overline{F}(X)} = 0$, thus
+$\text{id}_X = 0$ in $\mathcal{A}/\mathcal{C}$ by faithfulness of
+$\overline{F}$. Hence $X = 0$ in $\mathcal{A}/\mathcal{C}$, that is $X \in
+\Ob(\mathcal{C})$.
 \end{proof}
 
 

--- a/homology.tex
+++ b/homology.tex
@@ -1842,9 +1842,8 @@ faithful.
 This is true because the kernel of $\overline{F}$ is zero by
 construction. Namely, if $f : X \to Y$ is a morphism in
 $\mathcal{A}/\mathcal{C}$ such that $\overline{F}(f) = 0$, then
-$\Ker(f) \to X$ and $Y \to \Coker(f)$ are transformed
-into isomorphisms by $\overline{F}$, hence are isomorphisms by the
-remark on the kernel of $\overline{F}$. Thus $f = 0$.
+$\overline{F}(\Im(f)) = \Im(\overline{F}(f)) = 0$, hence $\Im(f) = 0$ by the
+assumption on the kernel of $F$. Thus $f = 0$.
 \end{proof}
 
 


### PR DESCRIPTION
The first commit changes the wording of the proof; I didn't quite follow the original argument. (In any case, there is a typo -- fixed by the commit: "assumption" instead of "remark".)

The second commit adds the (easy) converse of the statement. I added the converse and its proof directly into the original lemma, i.e. I didn't state the converse as a separate lemma. I hope this is the conventional practice.