### PR TITLE
Added observations on quotienting by torsion modules

### DIFF
--- a/algebra.tex
+++ b/algebra.tex
@@ -19470,6 +19470,18 @@ any finite $R$-module is finitely presented. In particular any ideal of $R$
 is finitely presented.
 \end{proof}
 
+\begin{lemma}
+\label{lemma-Noetherian-finitely-generated-modules-abelian}
+Let $R$ be a Noetherian ring. Then the category of finitely generated
+$R$-modules is an Abelian subcategory of $\text{Mod}_R$ and coincides with the
+category of coherent $R$-modules.
+\end{lemma}
+
+\begin{proof}
+Combine Lemmas \ref{lemma-Noetherian-coherent}, \ref{lemma-coherent-ring}, and
+\ref{lemma-Noetherian-finite-type-is-finite-presentation}.
+\end{proof}
+
 \begin{proposition}
 \label{proposition-characterize-coherent}
 Let $R$ be a ring. The following are equivalent

--- a/documentation/git-howto
+++ b/documentation/git-howto
@@ -64,7 +64,7 @@ for inclusion in the project.
 
 
 Keeping in sync with the main repository at github
---------------------------------------------
+--------------------------------------------------
 
 If you are worried about keeping in sync with the repository at github you
 can do the following steps
@@ -102,3 +102,6 @@ There is a lot more you can do with git. For example you can set it up so that
 the maintainer of the stacks project can pull changes directly from your own
 repository. To learn more see http://git-scm.com and
 http://www.kernel.org/pub/software/scm/git/docs/
+
+Do assign labels to new theorems, propositions, etc., but don't bother to
+assign tags.

--- a/examples.tex
+++ b/examples.tex
@@ -4934,6 +4934,85 @@ See discussion above.
 
 
 
+\section{The Serre quotient of a category of modules modulo its subcategory of
+torsion modules}
+\label{section-serre-quotient-modulo-torsion-modules}
+
+\begin{proposition}
+\label{proposition-quotient-by-torsion-modules}
+Let $A$ be an integral domain. Let $K$ denote its field of fractions. Let
+$\text{Mod}_A$ denote the category of $A$-modules and $\mathcal{T}$ its
+Serre subcategory of torsion modules. Let $\text{Vect}_K$ denote the category
+of $K$-vector spaces. Then there is a canonical exact equivalence
+$\text{Mod}_A/\mathcal{T} \rightarrow \text{Vect}_K$.
+\end{proposition}
+
+\begin{proof}
+The functor $\text{Mod}_A \to \textit{Vect}_K$ given by $M
+\mapsto M \otimes_A K$ is exact (by Algebra, Proposition
+\ref{algebra-proposition-localization-exact}) and maps torsion modules to zero.
+Thus, by the universal property given in Homology, Lemma
+\ref{homology-lemma-serre-subcategory-is-kernel}, the functor descends to a functor
+$\text{Mod}_A/\mathcal{T} \to \textit{Vect}_K$.
+
+\medskip\noindent
+Conversely, any $A$-module $M$ with $M \otimes_A K = 0$ is torsion, since $M
+\otimes_A K \cong M[S^{-1}]$, where $S \subset A$ is the set of regular
+elements (Algebra, Lemma \ref{algebra-lemma-tensor-localization}). Thus
+Homology, Lemma~\ref{homology-lemma-quotient-by-kernel-exact-functor} shows that the functor
+$\text{Mod}_A/\mathcal{T} \to \text{Vect}_K$ is faithful.
+
+\medskip\noindent
+Furthermore, this embedding is essentially surjective: a preimage to $K^{(I)}$ is
+$A^{(I)}$. To show that the embedding is full, we only have to show that it is full
+for free modules, since any object in $\text{Mod}_A/\mathcal{T}$ is the
+cokernel of a morphism between free modules.
+
+\medskip\noindent
+Thus let a $K$-linear map $K^{(I)} \to K^{(J)}$ be given. We can decompose
+this map into a scaling map $K^{(I)} \to K^{(I)}$, $e_i \mapsto d_i^{-1} e_i$ ($d_i \in
+A$), followed by a map $K^{(I)} \to K^{(J)}$ whose (possibly infinite) matrix
+has all entries in $A$. It is then obvious that the second map is induced by an
+$A$-linear map $A^{(I)} \to A^{(J)}$. The scaling map possesses a preimage in
+$\text{Mod}_A/\mathcal{T}$ as well, for it is the inverse to the map
+$A^{(I)} \to A^{(I)}$, $e_i \mapsto d_i$, in $\text{Mod}_A/\mathcal{T}$.
+This map is indeed invertible in $\text{Mod}_A/\mathcal{T}$, since its kernel is
+zero (even before passing to the quotient) and its cokernel is a torsion
+module.
+\end{proof}
+
+\begin{proposition}
+\label{proposition-quotient-by-finitely-generated-torsion-modules}
+Let $A$ be a Noetherian integral domain. Let $K$ denote its field of fractions. Let
+$\text{Mod}_A^{fg}$ denote the category of finitely generated $A$-modules and
+$\mathcal{T}^{fg}$ its Serre subcategory of finitely generated torsion modules. Then
+$\text{Mod}_A^{fg}/\mathcal{T}^{fg}$ is canonically equivalent to the category of
+finite dimensional $K$-vector spaces.
+\end{proposition}
+
+\begin{proof}
+The equivalence given in Proposition
+\ref{proposition-quotient-by-torsion-modules} restricts along the embedding
+$\text{Mod}_A^{fg}/\mathcal{T}^{fg} \to \text{Mod}_A/\mathcal{T}$ to an
+equivalence $\text{Mod}_A^{fg}/\mathcal{T}^{fg} \to \text{Vect}_K^{fd}$.
+The Noetherian assumption guarantees that $\text{Mod}_A^{fg}$ is indeed an
+Abelian category (see Algebra, Lemma
+\ref{lemma-Noetherian-finitely-generated-modules-abelian}) and that the
+canonical functor $\text{Mod}_A^{fg}/\mathcal{T}^{fg} \to
+\text{Mod}_A/\mathcal{T}$ is full (else torsion submodules of finitely
+generated modules might not be objects of $\mathcal{T}^{fg}$).
+\end{proof}
+
+\begin{proposition}
+\label{proposition-quotient-abelian-groups-by-torsion-groups}
+The quotient of the category of abelian groups modulo its
+Serre subcategory of torsion groups is the category of
+$\mathbf{Q}$-vector spaces.
+\end{proposition}
+
+\begin{proof}
+The claim follows directly from Proposition \ref{proposition-quotient-by-torsion-modules}.
+\end{proof}
 
 
 \input{chapters}

--- a/homology.tex
+++ b/homology.tex
@@ -1722,6 +1722,14 @@ the inclusion functor is exact.
 Omitted.
 \end{proof}
 
+\begin{example}
+\label{example-serre-subcategory-of-torsion-modules}
+The category of torsion groups is a Serre subcategory of the category of all
+abelian groups. More generally, for any ring $A$, the category of torsion
+$A$-modules (modules for which any element is annihilated by a regular element
+of $A$) is a Serre subcategory of the category of all $A$-modules.
+\end{example}
+
 \begin{lemma}
 \label{lemma-kernel-exact-functor}
 Let $\mathcal{A}$, $\mathcal{B}$ be abelian categories.
@@ -1853,6 +1861,70 @@ $\overline{F}$. Hence $X = 0$ in $\mathcal{A}/\mathcal{C}$, that is $X \in
 \Ob(\mathcal{C})$.
 \end{proof}
 
+\begin{proposition}
+\label{lemma-quotient-by-torsion-modules}
+Let $A$ be a ring. Let~$\textit{Coh}(A)$ be the abelian category of coherent
+$A$-modules and~$\mathcal{T}$ its Serre subcategory of torsion modules. Let $k$
+denote the total ring of fractions of $A$, that is the localization of $A$ at
+the set of its regular elements. Let $\mathcal{V}$ denote the category of
+finite dimensional $k$-vector spaces. Then there is a canonical exact faithful
+functor $\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$. If furthermore $A$ is a
+coherent ring, this functor is an equivalence.
+\end{proposition}
+
+\begin{proof}
+The functor $\textit{Coh}(A) \to \mathcal{V}$ given by $M
+\mapsto M \otimes_A k$ is exact (by Algebra, Proposition
+\ref{algebra-proposition-localization-exact}) and maps torsion modules to zero.
+Thus, by the universal property given in Lemma
+\ref{lemma-serre-subcategory-is-kernel}, the functor descends to a functor
+$\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$.
+
+\medskip\noindent
+We will now show that any finitely presented $A$-module $M$ with $M
+\otimes_A k = 0$ is a torsion module. By Lemma
+\ref{lemma-quotient-by-kernel-exact-functor}, this will imply that the induced functor
+$\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$ is faithful. Let $M$ be presented
+as $M = \Coker(P)$, where $P$ is a $(m \times n)$ matrix. Since
+$M \otimes_R k = \Coker(P \otimes \text{id}_k)$ is zero, $P \otimes
+\text{id}_k : k^n \to k^m$ is surjective. Therefore, for any $x \in A^m$, there
+exists $s \in k^n$ such that $x = Ps$ in $k^m$. Writing $s = s'/d$ with $s' \in A^n$ and
+$d$ a regular element of $A$, we obtain that $dx = Ps'$ in $A^m$. This shows that any
+element of $M$ is torsion.
+
+\medskip\noindent
+If $A$ is a coherent ring, then any finite free $A$-module is coherent
+by Algebra, Lemma \ref{algebra-lemma-coherent}. Therefore the inclusion
+$\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$ is essentially surjective.
+Furthermore, any linear map $\varphi : k^n \to k^m$ is the image of a morphism
+$A^n \to A^m$ in $\textit{Coh}(A)/\mathcal{T}$. This is because any such map
+can be written as $d^{-1} \cdot (\psi \otimes \text{id}_k)$, where $\psi$ is a
+linear map $A^n \to A^m$ and $d$ is a regular element of $A$, and
+multiplication by $d$ is in $\textit{Coh}(A)/\mathcal{T}$ an invertible
+morphism $A \to A$ (its kernel is zero even before passing to the quotient, and
+its cokernel is the torsion module $A/(d)$).
+
+\medskip\noindent
+Finally, notice that the embedding $\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$ is full,
+since any object in $\textit{Coh}(A)/\mathcal{T}$ is the cokernel of a morphism
+between finite free modules and the preceding paragraph shows that the
+embedding is full for finite free modules.
+\end{proof}
+
+\begin{proposition}
+\label{proposition-quotient-abelian-groups-by-torsion-groups}
+The quotient of the category of finitely presented abelian groups module its
+Serre subcategory of torsion groups is the category of finite dimensional
+$\mathbf{Q}$-vector spaces.
+\end{proposition}
+
+\begin{proof}
+Since $\mathbb{Z}$ is Noetherian, finitely presented abelian groups and
+coherent $\mathbb{Z}$-modules coincide (Algebra, Lemmas
+\ref{algebra-lemma-Noetherian-coherent} and \ref{algebra-lemma-coherent-ring}).
+Therefore the claim follows directly from Proposition
+\ref{lemma-quotient-by-torsion-modules}.
+\end{proof}
 
 
 

--- a/homology.tex
+++ b/homology.tex
@@ -1862,68 +1862,79 @@ $\overline{F}$. Hence $X = 0$ in $\mathcal{A}/\mathcal{C}$, that is $X \in
 \end{proof}
 
 \begin{proposition}
-\label{lemma-quotient-by-torsion-modules}
-Let $A$ be a ring. Let~$\textit{Coh}(A)$ be the abelian category of coherent
-$A$-modules and~$\mathcal{T}$ its Serre subcategory of torsion modules. Let $k$
-denote the total ring of fractions of $A$, that is the localization of $A$ at
-the set of its regular elements. Let $\mathcal{V}$ denote the category of
-finite dimensional $k$-vector spaces. Then there is a canonical exact faithful
-functor $\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$. If furthermore $A$ is a
-coherent ring, this functor is an equivalence.
+\label{proposition-quotient-by-torsion-modules}
+Let $A$ be an integral domain. Let $K$ denote its field of fractions. Let
+$\text{Mod}_A$ denote the category of $A$-modules and $\mathcal{T}$ its
+Serre subcategory of torsion modules. Let $\text{Vect}_K$ denote the category
+of $K$-vector spaces. Then there is a canonical exact equivalence
+$\text{Mod}_A/\mathcal{T} \rightarrow \text{Vect}_K$.
 \end{proposition}
 
 \begin{proof}
-The functor $\textit{Coh}(A) \to \mathcal{V}$ given by $M
-\mapsto M \otimes_A k$ is exact (by Algebra, Proposition
+The functor $\text{Mod}_A \to \textit{Vect}_K$ given by $M
+\mapsto M \otimes_A K$ is exact (by Algebra, Proposition
 \ref{algebra-proposition-localization-exact}) and maps torsion modules to zero.
 Thus, by the universal property given in Lemma
 \ref{lemma-serre-subcategory-is-kernel}, the functor descends to a functor
-$\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$.
+$\text{Mod}_A/\mathcal{T} \to \textit{Vect}_K$.
 
 \medskip\noindent
-We will now show that any finitely presented $A$-module $M$ with $M
-\otimes_A k = 0$ is a torsion module. By Lemma
-\ref{lemma-quotient-by-kernel-exact-functor}, this will imply that the induced functor
-$\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$ is faithful. Let $M$ be presented
-as $M = \Coker(P)$, where $P$ is a $(m \times n)$ matrix. Since
-$M \otimes_R k = \Coker(P \otimes \text{id}_k)$ is zero, $P \otimes
-\text{id}_k : k^n \to k^m$ is surjective. Therefore, for any $x \in A^m$, there
-exists $s \in k^n$ such that $x = Ps$ in $k^m$. Writing $s = s'/d$ with $s' \in A^n$ and
-$d$ a regular element of $A$, we obtain that $dx = Ps'$ in $A^m$. This shows that any
-element of $M$ is torsion.
+Conversely, any $A$-module $M$ with $M \otimes_A K = 0$ is torsion, since $M
+\otimes_A K \cong M[S^{-1}]$, where $S \subset A$ is the set of regular
+elements (Algebra, Lemma \ref{algebra-lemma-tensor-localization}). Thus
+Lemma~\ref{lemma-quotient-by-kernel-exact-functor} shows that the functor
+$\text{Mod}_A/\mathcal{T} \to \text{Vect}_K$ is faithful.
 
 \medskip\noindent
-If $A$ is a coherent ring, then any finite free $A$-module is coherent
-by Algebra, Lemma \ref{algebra-lemma-coherent}. Therefore the inclusion
-$\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$ is essentially surjective.
-Furthermore, any linear map $\varphi : k^n \to k^m$ is the image of a morphism
-$A^n \to A^m$ in $\textit{Coh}(A)/\mathcal{T}$. This is because any such map
-can be written as $d^{-1} \cdot (\psi \otimes \text{id}_k)$, where $\psi$ is a
-linear map $A^n \to A^m$ and $d$ is a regular element of $A$, and
-multiplication by $d$ is in $\textit{Coh}(A)/\mathcal{T}$ an invertible
-morphism $A \to A$ (its kernel is zero even before passing to the quotient, and
-its cokernel is the torsion module $A/(d)$).
+Furthermore, this embedding is essentially surjective: a preimage to $K^{(I)}$ is
+$A^{(I)}$. To show that the embedding is full, we only have to show that it is full
+for free modules, since any object in $\text{Mod}_A/\mathcal{T}$ is the
+cokernel of a morphism between free modules.
 
 \medskip\noindent
-Finally, notice that the embedding $\textit{Coh}(A)/\mathcal{T} \to \mathcal{V}$ is full,
-since any object in $\textit{Coh}(A)/\mathcal{T}$ is the cokernel of a morphism
-between finite free modules and the preceding paragraph shows that the
-embedding is full for finite free modules.
+Thus let a $K$-linear map $K^{(I)} \to K^{(J)}$ be given. We can decompose
+this map into a scaling map $K^{(I)} \to K^{(I)}$, $e_i \mapsto d_i^{-1} e_i$ ($d_i \in
+A$), followed by a map $K^{(I)} \to K^{(J)}$ whose (possibly infinite) matrix
+has all entries in $A$. It is then obvious that the second map is induced by an
+$A$-linear map $A^{(I)} \to A^{(J)}$. The scaling map possesses a preimage in
+$\text{Mod}_A/\mathcal{T}$ as well, for it is the inverse to the map
+$A^{(I)} \to A^{(I)}$, $e_i \mapsto d_i$, in $\text{Mod}_A/\mathcal{T}$.
+This map is indeed invertible in $\text{Mod}_A/\mathcal{T}$, since its kernel is
+zero (even before passing to the quotient) and its cokernel is a torsion
+module.
+\end{proof}
+
+\begin{proposition}
+\label{proposition-quotient-by-finitely-generated-torsion-modules}
+Let $A$ be a Noetherian integral domain. Let $K$ denote its field of fractions. Let
+$\text{Mod}_A^{fg}$ denote the category of finitely generated $A$-modules and
+$\mathcal{T}^{fg}$ its Serre subcategory of finitely generated torsion modules. Then
+$\text{Mod}_A^{fg}/\mathcal{T}^{fg}$ is canonically equivalent to the category of
+finite dimensional $K$-vector spaces.
+\end{proposition}
+
+\begin{proof}
+The equivalence given in Proposition
+\ref{proposition-quotient-by-torsion-modules} restricts along the embedding
+$\text{Mod}_A^{fg}/\mathcal{T}^{fg} \to \text{Mod}_A/\mathcal{T}$ to an
+equivalence $\text{Mod}_A^{fg}/\mathcal{T}^{fg} \to \text{Vect}_K^{fd}$.
+The Noetherian assumption guarantees that $\text{Mod}_A^{fg}$ is indeed an
+Abelian category (see Algebra, Lemma
+\ref{lemma-Noetherian-finitely-generated-modules-abelian}) and that the
+canonical functor $\text{Mod}_A^{fg}/\mathcal{T}^{fg} \to
+\text{Mod}_A/\mathcal{T}$ is full (else torsion submodules of finitely
+generated modules might not be objects of $\mathcal{T}^{fg}$).
 \end{proof}
 
 \begin{proposition}
 \label{proposition-quotient-abelian-groups-by-torsion-groups}
-The quotient of the category of finitely presented abelian groups module its
-Serre subcategory of torsion groups is the category of finite dimensional
+The quotient of the category of abelian groups modulo its
+Serre subcategory of torsion groups is the category of
 $\mathbf{Q}$-vector spaces.
 \end{proposition}
 
 \begin{proof}
-Since $\mathbb{Z}$ is Noetherian, finitely presented abelian groups and
-coherent $\mathbb{Z}$-modules coincide (Algebra, Lemmas
-\ref{algebra-lemma-Noetherian-coherent} and \ref{algebra-lemma-coherent-ring}).
-Therefore the claim follows directly from Proposition
-\ref{lemma-quotient-by-torsion-modules}.
+The claim follows directly from Proposition \ref{proposition-quotient-by-torsion-modules}.
 \end{proof}
 
 

--- a/homology.tex
+++ b/homology.tex
@@ -1722,14 +1722,6 @@ the inclusion functor is exact.
 Omitted.
 \end{proof}
 
-\begin{example}
-\label{example-serre-subcategory-of-torsion-modules}
-The category of torsion groups is a Serre subcategory of the category of all
-abelian groups. More generally, for any ring $A$, the category of torsion
-$A$-modules (modules for which any element is annihilated by a regular element
-of $A$) is a Serre subcategory of the category of all $A$-modules.
-\end{example}
-
 \begin{lemma}
 \label{lemma-kernel-exact-functor}
 Let $\mathcal{A}$, $\mathcal{B}$ be abelian categories.
@@ -1861,81 +1853,13 @@ $\overline{F}$. Hence $X = 0$ in $\mathcal{A}/\mathcal{C}$, that is $X \in
 \Ob(\mathcal{C})$.
 \end{proof}
 
-\begin{proposition}
-\label{proposition-quotient-by-torsion-modules}
-Let $A$ be an integral domain. Let $K$ denote its field of fractions. Let
-$\text{Mod}_A$ denote the category of $A$-modules and $\mathcal{T}$ its
-Serre subcategory of torsion modules. Let $\text{Vect}_K$ denote the category
-of $K$-vector spaces. Then there is a canonical exact equivalence
-$\text{Mod}_A/\mathcal{T} \rightarrow \text{Vect}_K$.
-\end{proposition}
-
-\begin{proof}
-The functor $\text{Mod}_A \to \textit{Vect}_K$ given by $M
-\mapsto M \otimes_A K$ is exact (by Algebra, Proposition
-\ref{algebra-proposition-localization-exact}) and maps torsion modules to zero.
-Thus, by the universal property given in Lemma
-\ref{lemma-serre-subcategory-is-kernel}, the functor descends to a functor
-$\text{Mod}_A/\mathcal{T} \to \textit{Vect}_K$.
-
-\medskip\noindent
-Conversely, any $A$-module $M$ with $M \otimes_A K = 0$ is torsion, since $M
-\otimes_A K \cong M[S^{-1}]$, where $S \subset A$ is the set of regular
-elements (Algebra, Lemma \ref{algebra-lemma-tensor-localization}). Thus
-Lemma~\ref{lemma-quotient-by-kernel-exact-functor} shows that the functor
-$\text{Mod}_A/\mathcal{T} \to \text{Vect}_K$ is faithful.
-
-\medskip\noindent
-Furthermore, this embedding is essentially surjective: a preimage to $K^{(I)}$ is
-$A^{(I)}$. To show that the embedding is full, we only have to show that it is full
-for free modules, since any object in $\text{Mod}_A/\mathcal{T}$ is the
-cokernel of a morphism between free modules.
-
-\medskip\noindent
-Thus let a $K$-linear map $K^{(I)} \to K^{(J)}$ be given. We can decompose
-this map into a scaling map $K^{(I)} \to K^{(I)}$, $e_i \mapsto d_i^{-1} e_i$ ($d_i \in
-A$), followed by a map $K^{(I)} \to K^{(J)}$ whose (possibly infinite) matrix
-has all entries in $A$. It is then obvious that the second map is induced by an
-$A$-linear map $A^{(I)} \to A^{(J)}$. The scaling map possesses a preimage in
-$\text{Mod}_A/\mathcal{T}$ as well, for it is the inverse to the map
-$A^{(I)} \to A^{(I)}$, $e_i \mapsto d_i$, in $\text{Mod}_A/\mathcal{T}$.
-This map is indeed invertible in $\text{Mod}_A/\mathcal{T}$, since its kernel is
-zero (even before passing to the quotient) and its cokernel is a torsion
-module.
-\end{proof}
-
-\begin{proposition}
-\label{proposition-quotient-by-finitely-generated-torsion-modules}
-Let $A$ be a Noetherian integral domain. Let $K$ denote its field of fractions. Let
-$\text{Mod}_A^{fg}$ denote the category of finitely generated $A$-modules and
-$\mathcal{T}^{fg}$ its Serre subcategory of finitely generated torsion modules. Then
-$\text{Mod}_A^{fg}/\mathcal{T}^{fg}$ is canonically equivalent to the category of
-finite dimensional $K$-vector spaces.
-\end{proposition}
-
-\begin{proof}
-The equivalence given in Proposition
-\ref{proposition-quotient-by-torsion-modules} restricts along the embedding
-$\text{Mod}_A^{fg}/\mathcal{T}^{fg} \to \text{Mod}_A/\mathcal{T}$ to an
-equivalence $\text{Mod}_A^{fg}/\mathcal{T}^{fg} \to \text{Vect}_K^{fd}$.
-The Noetherian assumption guarantees that $\text{Mod}_A^{fg}$ is indeed an
-Abelian category (see Algebra, Lemma
-\ref{lemma-Noetherian-finitely-generated-modules-abelian}) and that the
-canonical functor $\text{Mod}_A^{fg}/\mathcal{T}^{fg} \to
-\text{Mod}_A/\mathcal{T}$ is full (else torsion submodules of finitely
-generated modules might not be objects of $\mathcal{T}^{fg}$).
-\end{proof}
-
-\begin{proposition}
-\label{proposition-quotient-abelian-groups-by-torsion-groups}
-The quotient of the category of abelian groups modulo its
-Serre subcategory of torsion groups is the category of
-$\mathbf{Q}$-vector spaces.
-\end{proposition}
-
-\begin{proof}
-The claim follows directly from Proposition \ref{proposition-quotient-by-torsion-modules}.
-\end{proof}
+The category of torsion groups is a Serre subcategory of the category of all
+abelian groups. More generally, for any ring $A$, the category of torsion
+$A$-modules (modules for which any element is annihilated by a regular element
+of $A$) is a Serre subcategory of the category of all $A$-modules. See
+Examples, Section \ref{examples-section-serre-quotient-modulo-torsion-modules}
+for a proof that the resulting quotient category is equivalent to the category
+of vector spaces over the field of fractions of $A$.
 
 
 

--- a/tags/tags
+++ b/tags/tags
@@ -13805,3 +13805,6 @@
 0AZ1,chow-definition-degree-zero-cycle
 0AZ2,chow-lemma-spell-out-degree-zero-cycle
 0AZ3,chow-lemma-degree-vector-bundle
+0AZ4,homology-example-serre-subcategory-of-torsion-modules
+0AZ5,homology-lemma-quotient-by-torsion-modules
+0AZ6,homology-proposition-quotient-abelian-groups-by-torsion-groups

--- a/tags/tags
+++ b/tags/tags
@@ -13805,6 +13805,3 @@
 0AZ1,chow-definition-degree-zero-cycle
 0AZ2,chow-lemma-spell-out-degree-zero-cycle
 0AZ3,chow-lemma-degree-vector-bundle
-0AZ4,homology-example-serre-subcategory-of-torsion-modules
-0AZ5,homology-lemma-quotient-by-torsion-modules
-0AZ6,homology-proposition-quotient-abelian-groups-by-torsion-groups


### PR DESCRIPTION
This commit adds a discussion of the Serre quotient of the category of modules over some ring by the subcategory of torsion modules, which I'm told is the prototypical example of a Serre quotient.

Please check that the identification of the quotient given in the commit is correct. A result which is so basic must either be wrong or well-known, but I didn't find a statement of this kind in the literature.

If desired, I will gladly improve the wording or improve the pull request in other ways.