### PR TITLE
Removed macro from the bibliography

### DIFF
--- a/bibliography.tex
+++ b/bibliography.tex
@@ -3,8 +3,6 @@
 % OK, start here.
 %
 
-% TODO this macro should be removed from the bibliography
-\newcommand\PP{\mathbb{P}}
 \begin{document}
 
 \title{Bibliography}


### PR DESCRIPTION
Removed \PP macro. Did a global project search and it doesn’t seem to
be used anywhere.