### PR TITLE
Update categories.tex

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -487,7 +487,7 @@ $\Mor_\mathcal{C}(X, U)$. In other words $h_U$ is a presheaf.
 Given a morphism $f : X\to Y$ the corresponding map
 $h_U(f) :  \Mor_\mathcal{C}(Y, U)\to \Mor_\mathcal{C}(X, U)$
 takes $\phi$ to $\phi\circ f$. We will always denote
-this presheaf $h_U : \mathcal{C}^{opp} \to \textit{Sets}$.
+this presheaf $h_U : \mathcal{C} \to \textit{Sets}$.
 It is called the {\it representable presheaf} associated to $U$.
 If $\mathcal{C}$ is the category of schemes this functor is
 sometimes referred to as the


### PR DESCRIPTION
For consistency, a presheaf is "a contravariant functor
$F$ from $\mathcal{C}$ to $\textit{Sets}$.". So let it start from C and not C^{opp} :)