### PR TITLE
Try to correct a composition of morphisms

### DIFF
--- a/homology.tex
+++ b/homology.tex
@@ -722,7 +722,7 @@ $j:\Im(f)\to\Ker(g)$ be the canonical injection.
 Suppose (1) holds. Let $h:w\to y$ with $g\circ h=0$. There exists 
 $c:w\to\Ker(g)$ with $i\circ c=h$. 
 Let $v=x\times_{\Ker(g)}w$ with canonical projections 
-$k:v\to w$ and $l:v\to x$, so that $c\circ k=p\circ l$. 
+$k:v\to w$ and $l:v\to x$, so that $c\circ k=j\circ p\circ l$. 
 Then, $h\circ k=i\circ c\circ k=i\circ j\circ p\circ l=f\circ l$. 
 As $j\circ p$ is an epimorphism by hypothesis, $k$ is an 
 epimorphism by Lemma \ref{lemma-cartesian-cocartesian}. This implies (2).


### PR DESCRIPTION
I suggest at least this correction since the line after the correction doesn't follow otherwise. Technically, some identifications have been made without comment in this proof, i.e. between the image and coimage of $f$ (because abelian) and between the kernel of $g$ and the image of $f$ (because exact). And making these identifications has meant that some of the sequences of morphisms have gotten screwed up.