### PR TITLE
Making EPRINT and EPRINTTYPE consistent

### DIFF
--- a/my.bib
+++ b/my.bib
@@ -510,7 +510,7 @@
       YEAR        = {1997},
       VOLUME      = {127},
       PAGES       = {601--617},
-      EPRINT      = {arXiv: math.AG/9601011},
+      EPRINT      = {alg-geom/9601011},
 }
 
 @INCOLLECTION{cohomology-of-stacks,
@@ -574,7 +574,7 @@
       YEAR        = {1996},
       VOLUME      = {85},
       PAGES       = {1--60},
-      EPRINT      = {arXiv:math.AG/9506023},
+      EPRINT      = {alg-geom/9506023},
 }
 
 @UNPUBLISHED{stacks_book,
@@ -656,8 +656,8 @@
 @MISC{Bhatt,
    AUTHOR = {Bhatt, Bhargav and de Jong, Aise Johan},
     TITLE = {Crystalline cohomology and de Rham cohomology},
-   EPRINT = {arXiv:1110.5001v1},
-      URL = {http://arxiv.org/abs/1110.5001},
+   EPRINT = {1110.5001},
+    EPRINTTYPE = {arXiv},
      YEAR = {2011}
 }
 
@@ -675,17 +675,17 @@
   AUTHOR = {Bhatt, Bhargav},
   TITLE = {Algebraization and Tannaka duality},
   PAGES = {35},
-  EPRINT = {arXiv:1404.7483},
+  EPRINT = {1404.7483},
+    EPRINTTYPE = {arXiv},
   YEAR = {2014},
-  URL = {http://arxiv.org/abs/1404.7483},
 }
 
 @MISC{BhattSmallCMMod,
 	AUTHOR = {Bhatt, Bhargav},
 	TITLE = {On the non-existence of small {C}ohen-{M}acaulay algebras},
 	YEAR = {2012},
-	EPRINT = {arXiv:1207.5413},
-	URL = {http://arxiv.org/abs/1207.5413},
+	EPRINT = {1207.5413},
+    EPRINTTYPE = {arXiv},
 }
 
 @UNPUBLISHED{BS,
@@ -1395,8 +1395,8 @@
 	AUTHOR = {Emerton, Matthew and Gee, Toby},
 	TITLE = {``Scheme-theoretic images'' of morphisms of stacks},
 	YEAR = {2015},
-	EPRINT = {arXiv:1506.06146},
-	URL = {http://arxiv.org/abs/1506.06146},
+	EPRINT = {1506.06146},
+    EPRINTTYPE = {arXiv},
 }
 
 @BOOK{Engelking,
@@ -1597,8 +1597,8 @@
 @MISC{Fujiwara-Kato,
     AUTHOR = {Fujiwara, Kazuhiro and Kato, Fumiharu},
     TITLE = {Foundations of Rigid Geometry I},
-    EPRINT = {arXiv:1308.4734},
-    URL = {http://arxiv.org/abs/1308.4734},
+    EPRINT = {1308.4734},
+    EPRINTTYPE = {arXiv},
 }
 
 @ARTICLE{F69,
@@ -1646,7 +1646,7 @@
       PUBLISHER   = {American Mathematical Society},
       YEAR        = {1995},
       PAGES       = {45--96},
-      EPRINT      = {arXiv:math.AG/9608011},
+      EPRINT      = {alg-geom/9608011},
 }
 
 @ARTICLE{FM,
@@ -1719,16 +1719,16 @@
 	AUTHOR = {Geraschenko, Anton and Satriano, Matthew},
 	TITLE = {Toric Stacks {I}: The Theory of Stacky Fans},
 	YEAR = {2011},
-	EPRINT = {arXiv:1107.1906},
-	URL = {http://arxiv.org/abs/1107.1906},
+	EPRINT = {1107.1906},
+    EPRINTTYPE = {arXiv},
 }
 
 @ARTICLE{gs_toric2,
 	AUTHOR = {Geraschenko, Anton and Satriano, Matthew},
 	TITLE = {Toric Stacks {II}: Intrinsic Characterization of Toric Stacks},
 	YEAR = {2011},
-	EPRINT = {arXiv:1107.1907},
-	URL = {http://arxiv.org/abs/1107.1907},
+	EPRINT = {1107.1907},
+    EPRINTTYPE = {arXiv},
 }
 
 @ARTICLE{GibKM,
@@ -1738,7 +1738,7 @@
       VOLUME      = {15},
       PAGES       = {273--294},
       YEAR        = {2002},
-      EPRINT      = {arXiv:math.AG/0006208},
+      EPRINT      = {math/0006208},
 }
 % the TITLE field should be {Towards the ample cone of $\mgn"$, or rather $\mathcal{M}_{g,n}$
 
@@ -1760,7 +1760,6 @@
       YEAR = {1965},
      PAGES = {2666--2668},
 }
-% the page count seems weird and I can't immediately find this article to check things
 
 @ARTICLE{Gleason,
     AUTHOR = {Gleason, Andrew Mattei},
@@ -1824,7 +1823,7 @@
       TITLE       = {A note on {H}urwitz schemes of covers of a positive genus curve},
       NOTE        = {preprint},
       YEAR        = {2002},
-      EPRINT      = {arXiv:math.AG/0205056},
+      EPRINT      = {math/0205056},
 }
 
 @UNPUBLISHED{GHMS,
@@ -1832,7 +1831,8 @@
       TITLE  = {Rational connectivity and sections of families over curves},
       YEAR   = {2002},
       NOTE   = {submitted Ann. Sci. Ecole Norm. Sup.},
-      EPRINT = {arXiv:math.AG/0210225},
+      EPRINT = {math/0210225},
+    EPRINTTYPE = {arXiv},
 }
 
 @INCOLLECTION{GHMS2,
@@ -2132,40 +2132,40 @@
 	AUTHOR = {Hall, Jack},
 	TITLE = {Openness of versality via coherent functors},
 	YEAR = {2012},
-	EPRINT = {arXiv:1206.4182},
-	URL = {http://arxiv.org/pdf/math/1206.4182},
+	EPRINT = {1206.4182},
+    EPRINTTYPE = {arXiv},
 }
 
 @ARTICLE{Hall-Rydh,
 	AUTHOR = {Hall, Jack and Rydh, David},
 	TITLE = {General Hilbert stacks and Quot schemes},
 	YEAR = {2013},
-	EPRINT = {arXiv:1306.4118},
-	URL = {http://arxiv.org/pdf/math/1306.4118},
+	EPRINT = {1306.4118},
+    EPRINTTYPE = {arXiv},
 }
 
 @ARTICLE{rydh_axioms,
 	AUTHOR = {Hall, Jack and Rydh, David},
 	TITLE = {Artin's criteria for algebraicity revisited},
 	YEAR = {2012},
-	EPRINT = {arXiv:1306.4599},
-	URL = {http://arxiv.org/abs/1306.4599},
+	EPRINT = {1306.4599},
+    EPRINTTYPE = {arXiv},
 }
 
 @ARTICLE{Hall-Rydh-Hilbert,
 	AUTHOR = {Hall, Jack and Rydh, David},
 	TITLE = {The Hilbert stack},
 	YEAR = {2010},
-	EPRINT = {arXiv:1011.5484},
-	URL = {http://arxiv.org/pdf/math/1011.5484},
+	EPRINT = {1011.5484},
+    EPRINTTYPE = {arXiv},
 }
 
 @MISC{HL-P,
 	AUTHOR = {Halpern-Leistner, Daniel and Preygel, Anatoly},
 	TITLE = {Mapping stacks and categorical notions of properness},
 	YEAR = {2014},
-	EPRINT = {arXiv:1402.3204},
-	URL = {http://arxiv.org/abs/1402.3204},
+	EPRINT = {1402.3204},
+    EPRINTTYPE = {arXiv},
 }
 
 @ARTICLE{HMP,
@@ -2200,7 +2200,7 @@
       TITLE       = {Curves of Small Degree on Cubic Threefolds},
       NOTE        = {to appear in Rocky Mountain Journal of Math.},
       YEAR        = {2002},
-      EPRINT      = {arXiv: math.AG/0202067},
+      EPRINT      = {math/0202067},
 }
 
 @ARTICLE{HRS2,
@@ -2218,7 +2218,7 @@
       YEAR        = {2002},
       TITLE       = {{A}bel-{J}acobi maps associated to smooth cubic threefolds},
       NOTE        = {submitted Journal of Alg. Geom.},
-      EPRINT      = {ar{X}iv:math.AG/0202080},
+      EPRINT      = {math/0202080},
 }
 
 @UNPUBLISHED{HS,
@@ -2237,7 +2237,8 @@
     NUMBER = {1},
      PAGES = {35--92},
       ISSN = {0010-437X},
-    EPRINT = {arXiv:math.AG/0207257},
+    EPRINT = {math/0207257},
+    EPRINTTYPE = {arXiv},
 }
 
 @ARTICLE{HarTsch,
@@ -2544,7 +2545,7 @@
       YEAR        = {2000},
       VOLUME      = {5},
       PAGES       = {23--47},
-      EPRINT      = {arXiv:math.AG/9910058},
+      EPRINT      = {math/9910058},
 }
 
 @BOOK{cotangent,
@@ -2911,7 +2912,7 @@
       YEAR       = {1996},
       TITLE      = {Contractible extremal rays on {$\overline{M}_{0,n}$}},
       NOTE       = {preprint},
-      EPRINT     = {arXiv:alg-geom/9607009},
+      EPRINT     = {alg-geom/9607009},
 }
 
 @ARTICLE{Keel,
@@ -3013,7 +3014,7 @@
       PUBLISHER   = {World Scientific},
       YEAR        = {2001},
       CHAPTER     = {5},
-      EPRINT      = {arXiv:math.AG/0003168},
+      EPRINT      = {math/0003168},
 }
 
 @ARTICLE{misconceptions,
@@ -3125,8 +3126,8 @@
     AUTHOR = {Koll{\'a}r, J{\'a}nos},
     TITLE = {Quotients by finite equivalence relations},
     YEAR = {2008},
-    EPRINT = {arXiv:0812.3608v2 [math.AG]},
-    URL = {http://arxiv.org/abs/0812.3608},
+    EPRINT = {0812.3608},
+    EPRINTTYPE = {arXiv},
 }
 
 @ARTICLE{KollarSimple,
@@ -3195,7 +3196,7 @@
       PUBLISHER   = {Birkh{\"a}user},
       YEAR        = {1995},
       PAGES       = {335--368},
-      EPRINT      = {arXiv:hep-th/9405035},
+      EPRINT      = {hep-th/9405035},
 }
 
 @ARTICLE{kresch_cycle,
@@ -4040,9 +4041,9 @@
 	AUTHOR = {Neeman, Amnon},
 	TITLE = {An improvement on the base-change theorem and the functor f-shriek},
 	YEAR = {2014},
-	EPRINT = {arXiv:1406.7599},
-	URL = {http://arxiv.org/abs/1406.7599},
-}	
+	EPRINT = {1406.7599},
+    EPRINTTYPE = {arXiv},
+}
 
 @ARTICLE{Neeman-rigid,
     AUTHOR = {Neeman, A.},
@@ -4235,8 +4236,8 @@
   AUTHOR = {Osserman, Brian and Payne, Sam},
   TITLE = {Lifting tropical intersections},
   YEAR = {2010},
-  EPRINT = {arXiv:1007.1314v1},
-  URL = {http://arxiv.org/abs/1007.1314v1},
+  EPRINT = {1007.1314},
+    EPRINTTYPE = {arXiv},
 }
 
 %%%%%%%%%%%%%%%%%%%%%% P %%%%%%%%%%%%%%%%%%%%%%
@@ -4773,7 +4774,8 @@
 @ARTICLE{Schroeer,
     AUTHOR = {Schroeer, Stefan},
      TITLE = {Points in the fppf topology},
-    EPRINT = {arXiv:1407.5446 [math.AG]},
+    EPRINT = {1407.5446},
+    EPRINTTYPE = {arXiv},
       YEAR = {2014},
      PAGES = {24},
 }
@@ -5078,8 +5080,8 @@
    AUTHOR = {Temkin, Michael and Tyomkin, Ilya},
     TITLE = {Ferrand's pushouts for algebraic spaces},
      YEAR = {2013},
-   EPRINT = {arXiv:1305.6014},
-      URL = {http://arxiv.org/abs/1305.6014},
+   EPRINT = {1305.6014},
+    EPRINTTYPE = {arXiv},
 }
 
 @INCOLLECTION{TT,
@@ -5255,7 +5257,7 @@
       AUTHOR      = {Vistoli, Angelo},
       TITLE       = {Notes on {G}rothendieck topologies, fibered categories and descent theory},
       YEAR        = {2004},
-      EPRINT      = {arXiv:math/0412512},
+      EPRINT      = {math/0412512},
       URL         = {http://arxiv.org/abs/math/0412512},
 }
 
@@ -5320,7 +5322,7 @@
       YEAR = {1970},
      PAGES = {167--172},
 }
-		
+
 @ARTICLE{Warfield-Purity,
     AUTHOR = {Warfield, Jr., R. B.},
      TITLE = {Purity and algebraic compactness for modules},
@@ -5359,9 +5361,9 @@
 @ARTICLE{Arzdorf-Wewers,
    AUTHOR = {Arzdorf, K. and Wewers, S.},
     TITLE = {Another proof of the Semistable Reduction Theorem},
-   EPRINT = {arxiv:1211.4624},
+   EPRINT = {1211.4624},
+    EPRINTTYPE = {arXiv},
      YEAR = {2012},
-      URL = {http://arxiv.org/abs/1211.4624},
 }
 
 @BOOK{Winter,


### PR DESCRIPTION
In order to make `stacks-website` more aware of arXiv links, I needed to clean up these two fields.