### PR TITLE
minor bugs (in particular, missing definitions) mostly in homology.tex, take 2

### DIFF
--- a/algebra.tex
+++ b/algebra.tex
@@ -16597,6 +16597,9 @@ a {\it homotopy} between $\alpha$ and $\beta$ is given by
 a collection of maps $h_i : F_i \to G_{i + 1}$ such that
 $\alpha_i - \beta_i = d_{G, i + 1} \circ h_i +
 h_{i-1} \circ d_{F, i}$.
+Two maps $\alpha, \beta : F_{\bullet} \to G_{\bullet}$ are
+said to be {\it homotopic} if a homotopy between $\alpha$
+and $\beta$ exists.
 
 \medskip\noindent
 We will use a very similar notation regarding complexes

--- a/homology.tex
+++ b/homology.tex
@@ -2752,247 +2752,6 @@ $\mathcal{A} \to \text{CoCh}(\mathcal{A})$.
 
 
 
-\section{Truncation of complexes}
-\label{section-truncations}
-
-\noindent
-Let $\mathcal{A}$ be an abelian category.
-Let $A_\bullet$ be a chain complex. There
-are several ways to {\it truncate} the complex $A_\bullet$.
-\begin{enumerate}
-\item The {\it ``stupid'' truncation $\sigma_{\leq n}$}
-is the subcomplex $\sigma_{\leq n} A_\bullet$ defined
-by the rule $(\sigma_{\leq n} A_\bullet)_i = 0$ if
-$i > n$ and $(\sigma_{\leq n} A_\bullet)_i = A_i$ if
-$i \leq n$. In a picture
-$$
-\xymatrix{
-\sigma_{\leq n}A_\bullet \ar[d]  &
-\ldots \ar[r] &
-0 \ar[r] \ar[d] &
-A_n \ar[r] \ar[d] &
-A_{n - 1} \ar[r] \ar[d] &
-\ldots \\
-A_\bullet  &
-\ldots \ar[r] &
-A_{n + 1} \ar[r] &
-A_n \ar[r] &
-A_{n - 1} \ar[r] &
-\ldots
-}
-$$
-Note the property
-$\sigma_{\leq n}A_\bullet / \sigma_{\leq n - 1}A_\bullet = A_n[-n]$.
-\item The {\it ``stupid'' truncation $\sigma_{\geq n}$}
-is the quotient complex $\sigma_{\geq n} A_\bullet$ defined
-by the rule $(\sigma_{\geq n} A_\bullet)_i = A_i$ if
-$i \geq n$ and $(\sigma_{\geq n} A_\bullet)_i = 0$ if
-$i < n$. In a picture
-$$
-\xymatrix{
-A_\bullet \ar[d]  &
-\ldots \ar[r] &
-A_{n + 1} \ar[r] \ar[d] &
-A_n \ar[r] \ar[d] &
-A_{n - 1} \ar[r] \ar[d] &
-\ldots \\
-\sigma_{\geq n}A_\bullet  &
-\ldots \ar[r] &
-A_{n + 1} \ar[r] &
-A_n \ar[r] &
-0 \ar[r] &
-\ldots
-}
-$$
-The map of complexes
-$\sigma_{\geq n}A_\bullet \to \sigma_{\geq n + 1}A_\bullet$ is surjective
-with kernel $A_n[-n]$.
-\item The {\it canonical truncation} $\tau_{\geq n}A_\bullet$
-is defined by the picture
-$$
-\xymatrix{
-\tau_{\geq n}A_\bullet \ar[d]  &
-\ldots \ar[r] &
-A_{n + 1} \ar[r] \ar[d] &
-\Ker(d_n) \ar[r] \ar[d] &
-0 \ar[r] \ar[d] &
-\ldots \\
-A_\bullet  &
-\ldots \ar[r] &
-A_{n + 1} \ar[r] &
-A_n \ar[r] &
-A_{n - 1} \ar[r] &
-\ldots
-}
-$$
-Note that these complexes have the property that
-$$
-H_i(\tau_{\geq n}A_\bullet) =
-\left\{
-\begin{matrix}
-H_i(A_\bullet) & \text{if} & i \geq n \\
-0 & \text{if} & i < n
-\end{matrix}
-\right.
-$$
-\item The {\it canonical truncation} $\tau_{\leq n}A_\bullet$
-is defined by the picture
-$$
-\xymatrix{
-A_\bullet \ar[d]  &
-\ldots \ar[r] &
-A_{n + 1} \ar[r] \ar[d] &
-A_n \ar[r] \ar[d] &
-A_{n - 1} \ar[r] \ar[d] &
-\ldots \\
-\tau_{\leq n}A_\bullet  &
-\ldots \ar[r] &
-0 \ar[r] &
-\Coker(d_{n + 1}) \ar[r] &
-A_{n - 1} \ar[r] &
-\ldots
-}
-$$
-Note that these complexes have the property that
-$$
-H_i(\tau_{\leq n}A_\bullet) =
-\left\{
-\begin{matrix}
-H_i(A_\bullet) & \text{if} & i \leq n \\
-0 & \text{if} & i > n
-\end{matrix}
-\right.
-$$
-\end{enumerate}
-
-\noindent
-Let $\mathcal{A}$ be an abelian category.
-Let $A^\bullet$ be a cochain complex. There
-are four ways to truncate the complex $A^\bullet$.
-\begin{enumerate}
-\item The {\it ``stupid'' truncation $\sigma_{\geq n}$} is the subcomplex
-$\sigma_{\geq n} A^\bullet$ defined by the rule
-$(\sigma_{\geq n} A^\bullet)^i = 0$ if
-$i < n$ and $(\sigma_{\geq n} A^\bullet)^i = A_i$ if
-$i \geq n$. In a picture
-$$
-\xymatrix{
-\sigma_{\geq n}A^\bullet \ar[d]  &
-\ldots \ar[r] &
-0 \ar[r] \ar[d] &
-A^n \ar[r] \ar[d] &
-A^{n + 1} \ar[r] \ar[d] &
-\ldots \\
-A^\bullet  &
-\ldots \ar[r] &
-A^{n - 1} \ar[r] &
-A^n \ar[r] &
-A^{n + 1} \ar[r] &
-\ldots
-}
-$$
-Note the property
-$\sigma_{\geq n}A^\bullet / \sigma_{\geq n + 1}A^\bullet
-= A^n[-n]$.
-\item The {\it ``stupid'' truncation $\sigma_{\leq n}$}
-is the quotient complex $\sigma_{\leq n} A^\bullet$ defined
-by the rule $(\sigma_{\leq n} A^\bullet)^i = 0$ if
-$i > n$ and $(\sigma_{\leq n} A^\bullet)^i = A^i$ if
-$i \leq n$. In a picture
-$$
-\xymatrix{
-A^\bullet \ar[d]  &
-\ldots \ar[r] &
-A^{n - 1} \ar[r] \ar[d] &
-A^n \ar[r] \ar[d] &
-A^{n + 1} \ar[r] \ar[d] &
-\ldots \\
-\sigma_{\leq n}A^\bullet &
-\ldots \ar[r] &
-A^{n - 1} \ar[r] &
-A^n \ar[r] &
-0 \ar[r] &
-\ldots \\
-}
-$$
-The map of complexes
-$\sigma_{\leq n}A^\bullet \to \sigma_{\leq n - 1}A^\bullet$ is surjective
-with kernel $A^n[-n]$.
-\item The {\it canonical truncation} $\tau_{\leq n}A^\bullet$
-is defined by the picture
-$$
-\xymatrix{
-\tau_{\leq n}A^\bullet \ar[d]  &
-\ldots \ar[r] &
-A^{n - 1} \ar[r] \ar[d] &
-\Ker(d^n) \ar[r] \ar[d] &
-0 \ar[r] \ar[d] &
-\ldots \\
-A^\bullet  &
-\ldots \ar[r] &
-A^{n - 1} \ar[r] &
-A^n \ar[r] &
-A^{n + 1} \ar[r] &
-\ldots
-}
-$$
-Note that these complexes have the property that
-$$
-H^i(\tau_{\leq n}A^\bullet) =
-\left\{
-\begin{matrix}
-H^i(A^\bullet) & \text{if} & i \leq n \\
-0 & \text{if} & i > n
-\end{matrix}
-\right.
-$$
-\item The {\it canonical truncation} $\tau_{\geq n}A^\bullet$
-is defined by the picture
-$$
-\xymatrix{
-A^\bullet \ar[d] &
-\ldots \ar[r] &
-A^{n - 1} \ar[r] \ar[d] &
-A^n \ar[r] \ar[d] &
-A^{n + 1} \ar[r] \ar[d] &
-\ldots \\
-\tau_{\geq n}A^\bullet &
-\ldots \ar[r] &
-0 \ar[r] &
-\Coker(d^{n - 1}) \ar[r] &
-A^{n + 1} \ar[r] &
-\ldots
-}
-$$
-Note that these complexes have the property that
-$$
-H^i(\tau_{\geq n}A^\bullet) =
-\left\{
-\begin{matrix}
-0 & \text{if} & i < n \\
-H^i(A^\bullet) & \text{if} & i \geq n
-\end{matrix}
-\right.
-$$
-\end{enumerate}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 \section{Homotopy and the shift functor}
 \label{section-homotopy-shift}
 
@@ -3329,6 +3088,247 @@ $$
 Since $h^n = -g^n$ and since $d_{A[1]}^{n - 1} = -d_A^n$ we conclude that (2)
 holds.
 \end{proof}
+
+
+
+
+\section{Truncation of complexes}
+\label{section-truncations}
+
+\noindent
+Let $\mathcal{A}$ be an abelian category.
+Let $A_\bullet$ be a chain complex. There
+are several ways to {\it truncate} the complex $A_\bullet$.
+\begin{enumerate}
+\item The {\it ``stupid'' truncation $\sigma_{\leq n}$}
+is the subcomplex $\sigma_{\leq n} A_\bullet$ defined
+by the rule $(\sigma_{\leq n} A_\bullet)_i = 0$ if
+$i > n$ and $(\sigma_{\leq n} A_\bullet)_i = A_i$ if
+$i \leq n$. In a picture
+$$
+\xymatrix{
+\sigma_{\leq n}A_\bullet \ar[d]  &
+\ldots \ar[r] &
+0 \ar[r] \ar[d] &
+A_n \ar[r] \ar[d] &
+A_{n - 1} \ar[r] \ar[d] &
+\ldots \\
+A_\bullet  &
+\ldots \ar[r] &
+A_{n + 1} \ar[r] &
+A_n \ar[r] &
+A_{n - 1} \ar[r] &
+\ldots
+}
+$$
+Note the property
+$\sigma_{\leq n}A_\bullet / \sigma_{\leq n - 1}A_\bullet = A_n[-n]$.
+\item The {\it ``stupid'' truncation $\sigma_{\geq n}$}
+is the quotient complex $\sigma_{\geq n} A_\bullet$ defined
+by the rule $(\sigma_{\geq n} A_\bullet)_i = A_i$ if
+$i \geq n$ and $(\sigma_{\geq n} A_\bullet)_i = 0$ if
+$i < n$. In a picture
+$$
+\xymatrix{
+A_\bullet \ar[d]  &
+\ldots \ar[r] &
+A_{n + 1} \ar[r] \ar[d] &
+A_n \ar[r] \ar[d] &
+A_{n - 1} \ar[r] \ar[d] &
+\ldots \\
+\sigma_{\geq n}A_\bullet  &
+\ldots \ar[r] &
+A_{n + 1} \ar[r] &
+A_n \ar[r] &
+0 \ar[r] &
+\ldots
+}
+$$
+The map of complexes
+$\sigma_{\geq n}A_\bullet \to \sigma_{\geq n + 1}A_\bullet$ is surjective
+with kernel $A_n[-n]$.
+\item The {\it canonical truncation} $\tau_{\geq n}A_\bullet$
+is defined by the picture
+$$
+\xymatrix{
+\tau_{\geq n}A_\bullet \ar[d]  &
+\ldots \ar[r] &
+A_{n + 1} \ar[r] \ar[d] &
+\Ker(d_n) \ar[r] \ar[d] &
+0 \ar[r] \ar[d] &
+\ldots \\
+A_\bullet  &
+\ldots \ar[r] &
+A_{n + 1} \ar[r] &
+A_n \ar[r] &
+A_{n - 1} \ar[r] &
+\ldots
+}
+$$
+Note that these complexes have the property that
+$$
+H_i(\tau_{\geq n}A_\bullet) =
+\left\{
+\begin{matrix}
+H_i(A_\bullet) & \text{if} & i \geq n \\
+0 & \text{if} & i < n
+\end{matrix}
+\right.
+$$
+\item The {\it canonical truncation} $\tau_{\leq n}A_\bullet$
+is defined by the picture
+$$
+\xymatrix{
+A_\bullet \ar[d]  &
+\ldots \ar[r] &
+A_{n + 1} \ar[r] \ar[d] &
+A_n \ar[r] \ar[d] &
+A_{n - 1} \ar[r] \ar[d] &
+\ldots \\
+\tau_{\leq n}A_\bullet  &
+\ldots \ar[r] &
+0 \ar[r] &
+\Coker(d_{n + 1}) \ar[r] &
+A_{n - 1} \ar[r] &
+\ldots
+}
+$$
+Note that these complexes have the property that
+$$
+H_i(\tau_{\leq n}A_\bullet) =
+\left\{
+\begin{matrix}
+H_i(A_\bullet) & \text{if} & i \leq n \\
+0 & \text{if} & i > n
+\end{matrix}
+\right.
+$$
+\end{enumerate}
+
+\noindent
+Let $\mathcal{A}$ be an abelian category.
+Let $A^\bullet$ be a cochain complex. There
+are four ways to truncate the complex $A^\bullet$.
+\begin{enumerate}
+\item The {\it ``stupid'' truncation $\sigma_{\geq n}$} is the subcomplex
+$\sigma_{\geq n} A^\bullet$ defined by the rule
+$(\sigma_{\geq n} A^\bullet)^i = 0$ if
+$i < n$ and $(\sigma_{\geq n} A^\bullet)^i = A_i$ if
+$i \geq n$. In a picture
+$$
+\xymatrix{
+\sigma_{\geq n}A^\bullet \ar[d]  &
+\ldots \ar[r] &
+0 \ar[r] \ar[d] &
+A^n \ar[r] \ar[d] &
+A^{n + 1} \ar[r] \ar[d] &
+\ldots \\
+A^\bullet  &
+\ldots \ar[r] &
+A^{n - 1} \ar[r] &
+A^n \ar[r] &
+A^{n + 1} \ar[r] &
+\ldots
+}
+$$
+Note the property
+$\sigma_{\geq n}A^\bullet / \sigma_{\geq n + 1}A^\bullet
+= A^n[-n]$.
+\item The {\it ``stupid'' truncation $\sigma_{\leq n}$}
+is the quotient complex $\sigma_{\leq n} A^\bullet$ defined
+by the rule $(\sigma_{\leq n} A^\bullet)^i = 0$ if
+$i > n$ and $(\sigma_{\leq n} A^\bullet)^i = A^i$ if
+$i \leq n$. In a picture
+$$
+\xymatrix{
+A^\bullet \ar[d]  &
+\ldots \ar[r] &
+A^{n - 1} \ar[r] \ar[d] &
+A^n \ar[r] \ar[d] &
+A^{n + 1} \ar[r] \ar[d] &
+\ldots \\
+\sigma_{\leq n}A^\bullet &
+\ldots \ar[r] &
+A^{n - 1} \ar[r] &
+A^n \ar[r] &
+0 \ar[r] &
+\ldots \\
+}
+$$
+The map of complexes
+$\sigma_{\leq n}A^\bullet \to \sigma_{\leq n - 1}A^\bullet$ is surjective
+with kernel $A^n[-n]$.
+\item The {\it canonical truncation} $\tau_{\leq n}A^\bullet$
+is defined by the picture
+$$
+\xymatrix{
+\tau_{\leq n}A^\bullet \ar[d]  &
+\ldots \ar[r] &
+A^{n - 1} \ar[r] \ar[d] &
+\Ker(d^n) \ar[r] \ar[d] &
+0 \ar[r] \ar[d] &
+\ldots \\
+A^\bullet  &
+\ldots \ar[r] &
+A^{n - 1} \ar[r] &
+A^n \ar[r] &
+A^{n + 1} \ar[r] &
+\ldots
+}
+$$
+Note that these complexes have the property that
+$$
+H^i(\tau_{\leq n}A^\bullet) =
+\left\{
+\begin{matrix}
+H^i(A^\bullet) & \text{if} & i \leq n \\
+0 & \text{if} & i > n
+\end{matrix}
+\right.
+$$
+\item The {\it canonical truncation} $\tau_{\geq n}A^\bullet$
+is defined by the picture
+$$
+\xymatrix{
+A^\bullet \ar[d] &
+\ldots \ar[r] &
+A^{n - 1} \ar[r] \ar[d] &
+A^n \ar[r] \ar[d] &
+A^{n + 1} \ar[r] \ar[d] &
+\ldots \\
+\tau_{\geq n}A^\bullet &
+\ldots \ar[r] &
+0 \ar[r] &
+\Coker(d^{n - 1}) \ar[r] &
+A^{n + 1} \ar[r] &
+\ldots
+}
+$$
+Note that these complexes have the property that
+$$
+H^i(\tau_{\geq n}A^\bullet) =
+\left\{
+\begin{matrix}
+0 & \text{if} & i < n \\
+H^i(A^\bullet) & \text{if} & i \geq n
+\end{matrix}
+\right.
+$$
+\end{enumerate}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/homology.tex
+++ b/homology.tex
@@ -207,12 +207,6 @@ $i : z \to x$ such that (a) $f \circ i = 0$ and (b)
 for any $i' : z' \to x$ such that $f \circ i' = 0$ there
 exists a unique morphism $g : z' \to z$ such that
 $i' = i \circ g$.
-
-In other words, a kernel of $f$ is a final object
-in the category of morphisms $j : w \to x$ satisfying
-$f \circ w = 0$.
-Thus, a kernel of $f$ is unique (up to unique isomorphism)
-if it exists.
 \item If the kernel of $f$ exists, then we denote
 this $\Ker(f) \to x$.
 \item A {\it cokernel} of $f$ is a morphism
@@ -220,12 +214,6 @@ $p : y \to z$ such that (a) $p \circ f = 0$ and (b)
 for any $p' : y \to z'$ such that $p' \circ f = 0$ there
 exists a unique morphism $g : z \to z'$ such that
 $p' = g \circ p$.
-
-In other words, a cokernel of $f$ is an initial object
-in the category of morphisms $q : y \to w$ satisfying
-$q \circ f = 0$.
-Thus, a cokernel of $f$ is unique (up to unique isomorphism)
-if it exists.
 \item If a cokernel of $f$ exists we denote this
 $y \to \Coker(f)$.
 \item If a kernel of $f$ exists, then a {\it coimage
@@ -238,6 +226,20 @@ $f$} is a kernel of the morphism $y \to \Coker(f)$.
 this $\Im(f) \to y$.
 \end{enumerate}
 \end{definition}
+
+\noident
+In the above definition, we have spoken of ``the kernel''
+and ``the cokernel'', tacitly using their uniqueness
+(up to isomorphism).
+The reason for this uniqueness is the following:
+A kernel of a morphism $f : x \to y$ in a preadditive
+category $\mathcal{A}$ is a final object
+in the category of morphisms $j : w \to x$ satisfying
+$f \circ w = 0$; hence, it is unique (up to unique
+isomorphism) if it exists.
+Similarly, a cokernel of a morphism can be characterized
+as an initial object, whence it also is unique (up to
+unique isomorphism).
 
 \noindent
 We first relate the direct sum to kernels as follows.

--- a/homology.tex
+++ b/homology.tex
@@ -82,47 +82,8 @@ $\alpha : y \to z$ factors through it if and only if $\alpha = 0$.
 \end{lemma}
 
 \begin{proof}
-(1) $\Rightarrow$ (3):
-Assume that $x$ is an initial object.
-Then, there is a unique morphism in
-$\Mor_\mathcal{A}(x, x)$.
-Hence, any two morphisms in $\Mor_\mathcal{A}(x, x)$
-must be equal.
-In particular, the identity morphism $\text{id}_x$ equals
-the zero $0$ of the group $\Mor_\mathcal{A}(x, x)$.
-Thus, (3) holds.
-
-(3) $\Rightarrow$ (1):
-Assume that $\text{id}_x = 0$ in $\Mor_\mathcal{A}(x, x)$.
-Let $y$ be any object of $\mathcal{A}$.
-For any morphism $f : x \to y$, we have
-$f = f \circ \text{id}_x = 0$ (since $\text{id}_x = 0$).
-Hence, the only morphism $x \to y$ is $0$.
-Consequently, there is a unique morphism $x \to y$.
-This shows that $x$ is initial.
-Thus, (1) holds.
-
-We have now proven that (1) $\Leftrightarrow$ (3).
-A dual argument shows that (2) $\Leftrightarrow$ (3).
-Hence, the equivalence of (1), (2) and (3) is shown.
-
-It remains to prove that, assuming an object $0$ exists,
-any given morphism $\alpha : y \to z$ factors through $0$
-if and only if $\alpha = 0$.
-The ``if'' direction is easy (in fact, the composition
-of the zero morphisms $y \to 0$ and $0 \to z$ must be the
-zero morphism $y \to z$, since the composition map
-$\Mor_\mathcal{A}(y, 0) \times \Mor_\mathcal{A}(0, z)
-\to \Mor_\mathcal{A}(y, z)$ is bilinear;
-hence, the zero morphism $y \to z$ factors through the
-object $0$).
-The ``only if'' direction is also clear (in fact, $0$ is
-initial and final, whence any morphisms
-$y \to 0$ and $0 \to z$ must be the zeroes of the respective
-morphism groups, and so their composition must also be zero,
-since the composition map
-$\Mor_\mathcal{A}(y, 0) \times \Mor_\mathcal{A}(0, z)
-\to \Mor_\mathcal{A}(y, z)$ is bilinear).
+Omitted.
+(Bilinearity of the composition map is the main tool here.)
 \end{proof}
 
 \begin{definition}

--- a/homology.tex
+++ b/homology.tex
@@ -180,6 +180,7 @@ same relations (by additivity) and we see that $F(z)$ is
 a direct sum of $F(x)$ and $F(y)$.
 Hence, $F$ transforms direct sums to direct sums.
 
+\medskip\noindent
 To see that $F$ transforms zero to zero, use the
 characterization (3) of the zero object in
 Lemma \ref{lemma-preadditive-zero}.

--- a/homology.tex
+++ b/homology.tex
@@ -76,10 +76,9 @@ The following are equivalent
 \item $x$ is a final object, and
 \item $\text{id}_x = 0$ in $\Mor_\mathcal{A}(x, x)$.
 \end{enumerate}
-Such an object, if it exists, is denoted by $0$.
 
-Furthermore, if such an object $0$ exists, then a morphism
-$\alpha : y \to z$ factors through $0$ if and only if $\alpha = 0$.
+Furthermore, if such an object exists, then a morphism
+$\alpha : y \to z$ factors through it if and only if $\alpha = 0$.
 \end{lemma}
 
 \begin{proof}

--- a/homology.tex
+++ b/homology.tex
@@ -1039,6 +1039,18 @@ exact sequence
 $$
 0 \to A \to E \to B \to 0.
 $$
+An {\it morphism of extensions} between two
+extensions $0 \to A \to E \to B \to 0$ and
+$0 \to A \to F \to B \to 0$ means a morphism
+$f : E \to F$ in $\mathcal{A}$ making the diagram
+\[
+\xymatrix{
+0 \ar[r] & A \ar[r] \ar[d]^{\operatorname{id}} & E \ar[r] \ar[d]^f & B \ar[r] \ar[d]^{\operatorname{id}} & 0 \\
+0 \ar[r] & A \ar[r]                            & F \ar[r]          & B \ar[r]                            & 0
+}
+\]
+commutative.
+Thus, the extensions of $B$ by $A$ form a category.
 \end{definition}
 
 \noindent

--- a/homology.tex
+++ b/homology.tex
@@ -2330,15 +2330,19 @@ In other words, a chain complex $A_\bullet$ belongs to
 $\text{Ch}_{\geq 0}(\mathcal{A})$ if and only if
 $A_i = 0$ for all $i < 0$.
 A {\it homotopy $h$} between a pair of morphisms
-of chain complexes $f, g : A_\bullet \to B_\bullet$ is
+of chain complexes $f, g : A_\bullet \to B_\bullet$
 is a collection of morphisms $h_i : A_i \to B_{i + 1}$
 such that we have
 $$
 f_i - g_i = d_{i + 1} \circ h_i + h_{i - 1} \circ d_i
 $$
-for all $i$. Clearly, the notions of chain complex, morphism of
+for all $i$.
+Two morphisms $f, g : A_\bullet \to B_\bullet$ are
+said to be {\it homotopic} if a homotopy between $f$
+and $g$ exists.
+Clearly, the notions of chain complex, morphism of
 chain complexes, and homotopies between morphisms of chain complexes
-makes sense even in a preadditive category.
+make sense even in a preadditive category.
 
 \begin{lemma}
 \label{lemma-compose-homotopy}
@@ -2500,6 +2504,21 @@ C_i/\Im(d_{C, i + 1}) \ar[r] \ar[d]^{d_{C, i}} &
 $$
 \end{proof}
 
+\begin{definition}
+\label{definition-skyscraper-complex}
+Let $\mathcal{A}$ be an abelian category.
+Let $V$ be an object of $\mathcal{A}$.
+Then, there is a chain complex $A_\bullet$ such
+that $A_0 = V$ and $A_i = 0$ for all $i \neq 0$
+(which, of course, forces all $d_i$ to be zero maps).
+This chain complex is denoted by $V$ (by abuse of
+notation).
+Sending each object $V$ of $\mathcal{A}$ to its
+corresponding chain complex $V$ yields a full and
+faithful embedding of categories
+$\mathcal{A} \to \text{Ch}(\mathcal{A})$.
+\end{definition}
+
 \noindent
 A {\it cochain complex $A^\bullet$} in an additive category $\mathcal{A}$
 is a complex
@@ -2534,15 +2553,19 @@ In other words, a cochain complex $A^\bullet$ belongs to the subcategory
 $\text{CoCh}_{\geq 0}(\mathcal{A})$ if and only if
 $A^i = 0$ for all $i < 0$.
 A {\it homotopy $h$} between a pair of morphisms
-of cochain complexes $f, g : A^\bullet \to B^\bullet$ is
+of cochain complexes $f, g : A^\bullet \to B^\bullet$
 is a collection of morphisms $h^i : A^i \to B^{i - 1}$
 such that we have
 $$
 f^i - g^i = d^{i - 1} \circ h^i + h^{i + 1} \circ d^i
 $$
-for all $i$. Clearly, the notions of cochain complex, morphism of
+for all $i$.
+Two morphisms $f, g : A^\bullet \to B^\bullet$ are
+said to be {\it homotopic} if a homotopy between $f$
+and $g$ exists.
+Clearly, the notions of cochain complex, morphism of
 cochain complexes, and homotopies between morphisms of cochain complexes
-makes sense even in a preadditive category.
+make sense even in a preadditive category.
 
 \begin{lemma}
 \label{lemma-compose-homotopy-cochain}
@@ -2708,6 +2731,21 @@ C^i/\Im(d_C^{i - 1}) \ar[r] \ar[d]^{d_C^i} &
 }
 $$
 \end{proof}
+
+\begin{definition}
+\label{definition-skyscraper-cocomplex}
+Let $\mathcal{A}$ be an abelian category.
+Let $V$ be an object of $\mathcal{A}$.
+Then, there is a cochain complex $A^\bullet$ such
+that $A^0 = V$ and $A^i = 0$ for all $i \neq 0$
+(which, of course, forces all $d^i$ to be zero maps).
+This cochain complex is denoted by $V$ (by abuse of
+notation).
+Sending each object $V$ of $\mathcal{A}$ to its
+corresponding cochain complex $V$ yields a full and
+faithful embedding of categories
+$\mathcal{A} \to \text{CoCh}(\mathcal{A})$.
+\end{definition}
 
 
 
@@ -3656,7 +3694,7 @@ The proof of the other cases is similar.
 \label{lemma-pushout-filtered}
 Let $\mathcal{A}$ be an abelian category.
 Let $A, B, C \in \text{Fil}(\mathcal{A})$.
-Let $f : A \to B$ and $g : A \to C$ be morphisms
+Let $f : A \to B$ and $g : A \to C$ be morphisms.
 Then there exists a pushout
 $$
 \xymatrix{
@@ -3685,7 +3723,7 @@ Whence the last statement.
 \label{lemma-fibre-product-filtered}
 Let $\mathcal{A}$ be an abelian category.
 Let $A, B, C \in \text{Fil}(\mathcal{A})$.
-Let $f : B \to A$ and $g : C \to A$ be morphisms
+Let $f : B \to A$ and $g : C \to A$ be morphisms.
 Then there exists a fibre product
 $$
 \xymatrix{

--- a/homology.tex
+++ b/homology.tex
@@ -246,7 +246,7 @@ $i : z \to x$ such that (a) $f \circ i = 0$ and (b)
 for any $i' : z' \to x$ such that $f \circ i' = 0$ there
 exists a unique morphism $g : z' \to z$ such that
 $i' = i \circ g$.
-\par
+
 In other words, a kernel of $f$ is a final object
 in the category of morphisms $j : w \to x$ satisfying
 $f \circ w = 0$.
@@ -259,7 +259,7 @@ $p : y \to z$ such that (a) $p \circ f = 0$ and (b)
 for any $p' : y \to z'$ such that $p' \circ f = 0$ there
 exists a unique morphism $g : z \to z'$ such that
 $p' = g \circ p$.
-\par
+
 In other words, a cokernel of $f$ is an initial object
 in the category of morphisms $q : y \to w$ satisfying
 $q \circ f = 0$.
@@ -1197,12 +1197,12 @@ An {\it morphism of extensions} between two
 extensions $0 \to A \to E \to B \to 0$ and
 $0 \to A \to F \to B \to 0$ means a morphism
 $f : E \to F$ in $\mathcal{A}$ making the diagram
-\[
+$$
 \xymatrix{
-0 \ar[r] & A \ar[r] \ar[d]^{\operatorname{id}} & E \ar[r] \ar[d]^f & B \ar[r] \ar[d]^{\operatorname{id}} & 0 \\
-0 \ar[r] & A \ar[r]                            & F \ar[r]          & B \ar[r]                            & 0
+0 \ar[r] & A \ar[r] \ar[d]^{\text{id}} & E \ar[r] \ar[d]^f & B \ar[r] \ar[d]^{\text{id}} & 0 \\
+0 \ar[r] & A \ar[r]                    & F \ar[r]          & B \ar[r]                    & 0
 }
-\]
+$$
 commutative.
 Thus, the extensions of $B$ by $A$ form a category.
 \end{definition}

--- a/homology.tex
+++ b/homology.tex
@@ -76,12 +76,54 @@ The following are equivalent
 \item $x$ is a final object, and
 \item $\text{id}_x = 0$ in $\Mor_\mathcal{A}(x, x)$.
 \end{enumerate}
+Such an object, if it exists, is denoted by $0$.
+
 Furthermore, if such an object $0$ exists, then a morphism
-$\alpha : x \to y$ factors through $0$ if and only if $\alpha = 0$.
+$\alpha : y \to z$ factors through $0$ if and only if $\alpha = 0$.
 \end{lemma}
 
 \begin{proof}
-Omitted.
+(1) $\Rightarrow$ (3):
+Assume that $x$ is an initial object.
+Then, there is a unique morphism in
+$\Mor_\mathcal{A}(x, x)$.
+Hence, any two morphisms in $\Mor_\mathcal{A}(x, x)$
+must be equal.
+In particular, the identity morphism $\text{id}_x$ equals
+the zero $0$ of the group $\Mor_\mathcal{A}(x, x)$.
+Thus, (3) holds.
+
+(3) $\Rightarrow$ (1):
+Assume that $\text{id}_x = 0$ in $\Mor_\mathcal{A}(x, x)$.
+Let $y$ be any object of $\mathcal{A}$.
+For any morphism $f : x \to y$, we have
+$f = f \circ \text{id}_x = 0$ (since $\text{id}_x = 0$).
+Hence, the only morphism $x \to y$ is $0$.
+Consequently, there is a unique morphism $x \to y$.
+This shows that $x$ is initial.
+Thus, (1) holds.
+
+We have now proven that (1) $\Leftrightarrow$ (3).
+A dual argument shows that (2) $\Leftrightarrow$ (3).
+Hence, the equivalence of (1), (2) and (3) is shown.
+
+It remains to prove that, assuming an object $0$ exists,
+any given morphism $\alpha : y \to z$ factors through $0$
+if and only if $\alpha = 0$.
+The ``if'' direction is easy (in fact, the composition
+of the zero morphisms $y \to 0$ and $0 \to z$ must be the
+zero morphism $y \to z$, since the composition map
+$\Mor_\mathcal{A}(y, 0) \times \Mor_\mathcal{A}(0, z)
+\to \Mor_\mathcal{A}(y, z)$ is bilinear;
+hence, the zero morphism $y \to z$ factors through the
+object $0$).
+The ``only if'' direction is also clear (in fact, $0$ is
+initial and final, whence any morphisms
+$y \to 0$ and $0 \to z$ must be the zeroes of the respective
+morphism groups, and so their composition must also be zero,
+since the composition map
+$\Mor_\mathcal{A}(y, 0) \times \Mor_\mathcal{A}(0, z)
+\to \Mor_\mathcal{A}(y, z)$ is bilinear).
 \end{proof}
 
 \begin{definition}

--- a/homology.tex
+++ b/homology.tex
@@ -304,6 +304,46 @@ is the identity on $x$. The proof of the second statement is dual.
 \end{proof}
 
 \begin{lemma}
+\label{lemma-kernel-mono}
+Let $\mathcal{C}$ be a preadditive category.
+Let $f : x \to y$ be a morphism in $\mathcal{C}$.
+\begin{enumerate}
+\item If a kernel of $f$ exists, then
+it is a monomorphism.
+\item If a cokernel of $f$ exists, then
+it is an epimorphism.
+\item If a kernel and coimage of $f$ exist, then
+the coimage is an epimorphism.
+\item If a cokernel and image of $f$ exist, then
+the image is a monomorphism.
+\end{enumerate}
+\end{lemma}
+
+\begin{proof}
+(1) Assume that a kernel $i : \Ker(f) \to x$ of $f$ exists.
+Let $\alpha : w \to \Ker(f)$ and $\beta : w \to \Ker(f)$
+be two morphisms satisfying $i \circ \alpha = i \circ \beta$.
+We must prove that $\alpha = \beta$.
+
+The definition of $\Ker(f)$ shows that for any
+$i' : w \to x$ such that $f \circ i' = 0$, there exists a
+unique morphism $g : w \to z$ such that $i' = i \circ g$.
+Applying this to $i' = i \circ \alpha = i \circ \beta$,
+we conclude that there exists a
+unique morphism $g : w \to z$ such that $i' = i \circ g$,
+where $i' = i \circ \alpha = i \circ \beta$.
+In particular, any two such morphisms $g$ must be equal.
+Since both $\alpha$ and $\beta$ fit the bill, we thus
+obtain $\alpha = \beta$, as desired.
+This proves (1).
+
+The proof of (2) is dual.
+
+(3) follows from (2), since the coimage is a cokernel.
+Similarly, (4) follows from (1).
+\end{proof}
+
+\begin{lemma}
 \label{lemma-coim-im-map}
 Let $f : x \to y$ be a morphism in a preadditive category
 such that the kernel, cokernel, image and coimage all exist.
@@ -317,7 +357,10 @@ because $\Ker(f) \to x \to y$ is zero.
 The composition $\Coim(f) \to y \to \Coker(f)$
 is zero, because it is the unique morphism which gives
 rise to the morphism $x \to y \to \Coker(f)$ which
-is zero. Hence $\Coim(f) \to y$ factors uniquely through
+is zero
+(the uniqueness follows from
+Lemma \ref{lemma-kernel-mono} (3)).
+Hence $\Coim(f) \to y$ factors uniquely through
 $\Im(f) \to y$, which gives us the desired map.
 \end{proof}
 

--- a/homology.tex
+++ b/homology.tex
@@ -3123,6 +3123,10 @@ A_{n - 1} \ar[r] &
 $$
 Note the property
 $\sigma_{\leq n}A_\bullet / \sigma_{\leq n - 1}A_\bullet = A_n[-n]$.
+(Here, $A_n[-n]$ means the $-n$-shifted chain complex of $A_n$,
+where the chain complex $A_n$ is defined as in
+Definition \ref{definition-skyscraper-complex} from the
+object $A_n \in \mathcal{A}$.)
 \item The {\it ``stupid'' truncation $\sigma_{\geq n}$}
 is the quotient complex $\sigma_{\geq n} A_\bullet$ defined
 by the rule $(\sigma_{\geq n} A_\bullet)_i = A_i$ if
@@ -3234,6 +3238,10 @@ $$
 Note the property
 $\sigma_{\geq n}A^\bullet / \sigma_{\geq n + 1}A^\bullet
 = A^n[-n]$.
+(Here, $A^n[-n]$ means the $-n$-shifted cochain complex of $A^n$,
+where the cochain complex $A^n$ is defined as in
+Definition \ref{definition-skyscraper-cocomplex} from the
+object $A^n \in \mathcal{A}$.)
 \item The {\it ``stupid'' truncation $\sigma_{\leq n}$}
 is the quotient complex $\sigma_{\leq n} A^\bullet$ defined
 by the rule $(\sigma_{\leq n} A^\bullet)^i = 0$ if

--- a/homology.tex
+++ b/homology.tex
@@ -246,6 +246,12 @@ $i : z \to x$ such that (a) $f \circ i = 0$ and (b)
 for any $i' : z' \to x$ such that $f \circ i' = 0$ there
 exists a unique morphism $g : z' \to z$ such that
 $i' = i \circ g$.
+\par
+In other words, a kernel of $f$ is a final object
+in the category of morphisms $j : w \to x$ satisfying
+$f \circ w = 0$.
+Thus, a kernel of $f$ is unique (up to unique isomorphism)
+if it exists.
 \item If the kernel of $f$ exists, then we denote
 this $\Ker(f) \to x$.
 \item A {\it cokernel} of $f$ is a morphism
@@ -253,6 +259,12 @@ $p : y \to z$ such that (a) $p \circ f = 0$ and (b)
 for any $p' : y \to z'$ such that $p' \circ f = 0$ there
 exists a unique morphism $g : z \to z'$ such that
 $p' = g \circ p$.
+\par
+In other words, a cokernel of $f$ is an initial object
+in the category of morphisms $q : y \to w$ satisfying
+$q \circ f = 0$.
+Thus, a cokernel of $f$ is unique (up to unique isomorphism)
+if it exists.
 \item If a cokernel of $f$ exists we denote this
 $y \to \Coker(f)$.
 \item If a kernel of $f$ exists, then a {\it coimage

--- a/homology.tex
+++ b/homology.tex
@@ -283,25 +283,8 @@ the image is a monomorphism.
 \end{lemma}
 
 \begin{proof}
-(1) Assume that a kernel $i : \Ker(f) \to x$ of $f$ exists.
-Let $\alpha : w \to \Ker(f)$ and $\beta : w \to \Ker(f)$
-be two morphisms satisfying $i \circ \alpha = i \circ \beta$.
-We must prove that $\alpha = \beta$.
-
-The definition of $\Ker(f)$ shows that for any
-$i' : w \to x$ such that $f \circ i' = 0$, there exists a
-unique morphism $g : w \to z$ such that $i' = i \circ g$.
-Applying this to $i' = i \circ \alpha = i \circ \beta$,
-we conclude that there exists a
-unique morphism $g : w \to z$ such that $i' = i \circ g$,
-where $i' = i \circ \alpha = i \circ \beta$.
-In particular, any two such morphisms $g$ must be equal.
-Since both $\alpha$ and $\beta$ fit the bill, we thus
-obtain $\alpha = \beta$, as desired.
-This proves (1).
-
-The proof of (2) is dual.
-
+(1) follows easily from the uniqueness required in the
+definition of a kernel. The proof of (2) is dual.
 (3) follows from (2), since the coimage is a cokernel.
 Similarly, (4) follows from (1).
 \end{proof}

--- a/homology.tex
+++ b/homology.tex
@@ -218,6 +218,11 @@ to Remark \ref{remark-direct-sum}. Clearly $F(x), F(y), F(z)$
 and the morphisms $F(i), F(j), F(p), F(q)$ satisfy exactly the
 same relations (by additivity) and we see that $F(z)$ is
 a direct sum of $F(x)$ and $F(y)$.
+Hence, $F$ transforms direct sums to direct sums.
+
+To see that $F$ transforms zero to zero, use the
+characterization (3) of the zero object in
+Lemma \ref{lemma-preadditive-zero}.
 \end{proof}
 
 \begin{definition}
@@ -275,8 +280,8 @@ a cokernel for $j$.
 \end{lemma}
 
 \begin{proof}
-Let $f : z \to x \oplus y$ be a morphism such that $q \circ f = 0$.
-We have to show that there exists a unique morphism $g : z \to x$
+Let $f : z' \to x \oplus y$ be a morphism such that $q \circ f = 0$.
+We have to show that there exists a unique morphism $g : z' \to x$
 such that $f = i \circ g$. Since $i \circ p + j \circ q$ is the identity on
 $x \oplus y$ we see that
 $$

--- a/homology.tex
+++ b/homology.tex
@@ -309,9 +309,9 @@ Let $\mathcal{C}$ be a preadditive category.
 Let $f : x \to y$ be a morphism in $\mathcal{C}$.
 \begin{enumerate}
 \item If a kernel of $f$ exists, then
-it is a monomorphism.
+this kernel is a monomorphism.
 \item If a cokernel of $f$ exists, then
-it is an epimorphism.
+this cokernel is an epimorphism.
 \item If a kernel and coimage of $f$ exist, then
 the coimage is an epimorphism.
 \item If a cokernel and image of $f$ exist, then
@@ -530,7 +530,17 @@ $\mathcal{A}$ is abelian if and only if $\mathcal{A}^{opp}$ is abelian.
 \end{lemma}
 
 \begin{proof}
-Omitted.
+The first statement is straightforward.
+To see that $\mathcal{A}$ is additive if and only if $\mathcal{A}^{opp}$
+is additive, just recall that additivity can be characterized by
+the existence of a zero object and direct sums, which are both
+preserved when passing to the opposite category.
+Finally, to see that
+$\mathcal{A}$ is abelian if and only if $\mathcal{A}^{opp}$ is abelian,
+observes that kernels, cokernels, images and coimages in
+$\mathcal{A}^{opp}$ correspond to
+cokernels, kernels, coimages and images in $\mathcal{A}$,
+respectively.
 \end{proof}
 
 \begin{definition}
@@ -555,7 +565,49 @@ Let $f : x \to y$ be a morphism in an abelian category. Then
 \end{lemma}
 
 \begin{proof}
-Omitted.
+(1) $\Rightarrow$:
+Assume first that $f$ is injective.
+We must show that $f$ is a monomorphism.
+In other words, we must prove that if $\alpha : w \to x$
+and $\beta : w \to x$ satisfy $f \circ \alpha = f \circ \beta$,
+then $\alpha = \beta$.
+Consider such $\alpha$ and $\beta$.
+
+Since composition of morphisms is bilinear, we have
+$f \circ \left(\alpha - \beta\right)
+= f \circ \alpha - f \circ \beta = 0$.
+Thus, the morphism $\alpha - \beta : w \to x$ factors
+uniquely through $\Ker(f)$ (by the definition of the kernel).
+Since $\Ker(f) = 0$ (because $f$ is injective), this shows
+that $\alpha - \beta$ factors through $0$, hence is the
+zero morphism (by the last claim of
+Lemma \ref{lemma-preadditive-zero}).
+In other words, $\alpha = \beta$.
+This shows that $f$ is a monomorphism.
+
+$\Leftarrow$:
+Assume that $f$ is a monomorphism.
+We must show that $f$ is injective.
+
+Let $i : \Ker(f) \to x$ be the kernel of $f$.
+Compare this with the zero morphism $0 : \Ker(f) \to x$.
+Both morphisms $i$ and $0$ become zero when composed
+with $f$ (since $f \circ i = 0 = f \circ 0$), and thus
+must be equal (since $f$ is a monomorphism).
+Hence, $i = 0$.
+But Lemma \ref{lemma-kernel-mono} (1) shows that
+$i$ is a monomorphism.
+Hence, from $i \circ \text{id}_{\Ker(f)} = i = 0
+= i \circ 0$, we obtain $\text{id}_{\Ker(f)} = 0$.
+By the equivalent condition (3) of
+Lemma \ref{lemma-preadditive-zero}, this shows that
+$\Ker(f)$ is the zero object.
+In other words, $f$ is injective.
+
+Hence, we have proven claim (1).
+Claim (2) is shown in a dual fashion (or by applying
+claim (1) to the opposite category
+$\mathcal{A}^{opp}$).
 \end{proof}
 
 \noindent


### PR DESCRIPTION
This is https://github.com/stacks/stacks-project/pull/36 with your changes worked in, with two exceptions:

- I don't feel like I could formulate the skyscraper replacement well, sorry.

- My proof of lemma-characterize-injective is not a one-step argument; I would not summarize it as "follows directly from Lemma \ref{lemma-kernel-mono}" or in any other similarly short way. Am I overcomplicating it?