### PR TITLE
Fixed typo: approximating by perfect complex

### DIFF
--- a/quot.tex
+++ b/quot.tex
@@ -605,7 +605,7 @@ We may replace $X$ by a quasi-compact open neighbourhood of
 the support of $\mathcal{G}$, hence we may assume $X$ is Noetherian.
 In this case $X$ and $f$ are quasi-compact and quasi-separated.
 Choose an approximation $P \to \mathcal{F}$ by a perfect complex $P$ of
-the triple $(X, \mathcal{F}, 0)$, see
+the triple $(X, \mathcal{F}, -1)$, see
 Derived Categories of Spaces, Definition
 \ref{spaces-perfect-definition-approximation-holds} and
 Theorem \ref{spaces-perfect-theorem-approximation}).


### PR DESCRIPTION
The index is wrong. It should be -1, not 0. (See diff for relevant line.)