### PR TITLE
Typos + Small change to please MathJax

### DIFF
--- a/exercises.tex
+++ b/exercises.tex
@@ -2543,10 +2543,10 @@ in $x_1, \ldots, x_n$.
 
 \begin{exercise}
 \label{exercise-extra-function-cone}
-Give an example of am affine variety $X \subset \mathbf{C}^n$
+Give an example of an affine variety $X \subset \mathbf{C}^n$
 which is a cone (see Exercise \ref{exercise-cone})
 and a regular function $f$ on $U = X \setminus \{(0, \ldots, 0)\}$
-which is not the restruction of a polynomial
+which is not the restriction of a polynomial
 function on $\mathbf{C}^n$.
 \end{exercise}
 

--- a/hypercovering.tex
+++ b/hypercovering.tex
@@ -778,7 +778,7 @@ It defines a functor
 \end{eqnarray*}
 Thus a simplicial object $K$ of $\text{SR}(\mathcal{C})$
 is turned into a cosimplicial object $\mathcal{F}(K)$ of $\textit{Ab}$.
-The cochain complex $s(\mathcal{F})(K))$ associated to $\mathcal{F}(K)$
+The cochain complex $s(\mathcal{F}(K))$ associated to $\mathcal{F}(K)$
 (Simplicial, Section
 \ref{simplicial-section-dold-kan-cosimplicial})
 is called the {\v C}ech complex of $\mathcal{F}$ with

--- a/moduli-curves.tex
+++ b/moduli-curves.tex
@@ -259,7 +259,7 @@ assume $X_i$ is H-projective over $S_i$.
 \end{lemma}
 
 \begin{proof}
-This is an immediate corrolary of
+This is an immediate corollary of
 Lemma \ref{lemma-polarized-curves-over-curves}.
 Namely, unwinding the definitions, this lemma gives there is a
 surjective smooth morphism $S' \to S$ such that $X' = X \times_S S'$

--- a/simplicial.tex
+++ b/simplicial.tex
@@ -2842,7 +2842,7 @@ the commutative diagram
 $$
 \xymatrix{
 [0] \ar[rd]_{0 \mapsto 0} \ar[rrrrrd]^{0 \mapsto i} \\
-& [1] \ar[rrrr]^{0 \mapsto i, 1\mapsto i + 1} & & & & [n] \\ \relax
+& [1] \ar[rrrr]^{0 \mapsto i, 1\mapsto i + 1} & & & & [n] \\
 [0] \ar[ru]^{0 \mapsto 1} \ar[rrrrru]_{0 \mapsto i + 1}
 }
 $$

--- a/spaces-divisors.tex
+++ b/spaces-divisors.tex
@@ -2397,7 +2397,7 @@ Let $\mathcal{L}$ be an invertible $\mathcal{O}_X$-module.
 We say $\mathcal{L}$ is {\it relatively ample}, or {\it $f$-relatively ample},
 or {\it ample on $X/Y$}, or {\it $f$-ample} if $f : X \to Y$
 is representable and for every morphism $Z \to Y$
-where $Z$ is a scheme, the pullback $\mathcal{L}_T$ of $\mathcal{L}$
+where $Z$ is a scheme, the pullback $\mathcal{L}_Z$ of $\mathcal{L}$
 to $X_Z = Z \times_Y X$ is ample on $X_Z/Z$ as in
 Morphisms, Definition \ref{morphisms-definition-relatively-ample}.
 \end{definition}


### PR DESCRIPTION
Commit 97c59b5 fixes minor typos that I have come across.

More importantly, 38740bf fixes a MathJax issue---that is occurring on the Stacks Project right now, see [Tag 018I](https://stacks.math.columbia.edu/tag/018I)! Turns out that MathJax does not know the `\relax` primitive. Anyway, thanks to the solution offered in the discussion [here](https://github.com/pbelmans/plastex/issues/3), the `\relax` is no longer needed to placate plasTeX.