### PR TITLE
Formulate the statement in more generality and streamline its proof

### DIFF
--- a/examples.tex
+++ b/examples.tex
@@ -5525,50 +5525,54 @@ More on Algebra, Section \ref{more-algebra-section-abelian-categories-modules}.
 If $A$ is a domain, then the quotient category
 (Homology, Lemma \ref{homology-lemma-serre-subcategory-is-kernel})
 is equivalent to the category of vector spaces over the fraction field.
+This follows from the following more general proposition.
 
 \begin{proposition}
-\label{proposition-quotient-by-torsion-modules}
-Let $A$ be an integral domain. Let $K$ denote its field of fractions. Let
-$\text{Mod}_A$ denote the category of $A$-modules and $\mathcal{T}$ its
-Serre subcategory of torsion modules. Let $\text{Vect}_K$ denote the category
-of $K$-vector spaces. Then there is a canonical equivalence
-$\text{Mod}_A/\mathcal{T} \rightarrow \text{Vect}_K$.
+\label{proposition-localization-and-serre-quotients}
+Let $A$ be a ring. Let $S$ be a multiplicative subset of $A$.
+Let $\text{Mod}_A$ denote the category of $A$-modules and $\mathcal{T}$ its
+Serre subcategory of modules for which any element is annihilated by some
+element of $S$. Then there is a canonical equivalence
+$\text{Mod}_A/\mathcal{T} \rightarrow \text{Mod}_{S^{-1}A}$.
 \end{proposition}
 
 \begin{proof}
-The functor $\text{Mod}_A \to \text{Vect}_K$ given by $M
-\mapsto M \otimes_A K$ is exact (by Algebra, Proposition
-\ref{algebra-proposition-localization-exact}) and maps torsion modules to zero.
+The functor $\text{Mod}_A \to \text{Mod}_{S^{-1}A}$ given by $M
+\mapsto M \otimes_A S^{-1}A$ is exact (by Algebra, Proposition
+\ref{algebra-proposition-localization-exact}) and maps modules in $\mathcal{T}$ to zero.
 Thus, by the universal property given in Homology, Lemma
 \ref{homology-lemma-serre-subcategory-is-kernel}, the functor descends to a
-functor $\text{Mod}_A/\mathcal{T} \to \text{Vect}_K$.
+functor $\text{Mod}_A/\mathcal{T} \to \text{Mod}_{S^{-1}A}$.
 
 \medskip\noindent
-Conversely, any $A$-module $M$ with $M \otimes_A K = 0$ is torsion, since
-$M \otimes_A K \cong M[S^{-1}]$, where $S \subset A$ is the set of regular
-elements (Algebra, Lemma \ref{algebra-lemma-tensor-localization}). Thus
+Conversely, any $A$-module $M$ with $M \otimes_A S^{-1}A = 0$ is an object of $\mathcal{T}$, since
+$M \otimes_A S^{-1}A \cong S^{-1} M$ (Algebra, Lemma \ref{algebra-lemma-tensor-localization}). Thus
 Homology, Lemma \ref{homology-lemma-quotient-by-kernel-exact-functor}
 shows that the functor
-$\text{Mod}_A/\mathcal{T} \to \text{Vect}_K$ is faithful.
+$\text{Mod}_A/\mathcal{T} \to \text{Mod}_{S^{-1}A}$ is faithful.
 
 \medskip\noindent
-Furthermore, this embedding is essentially surjective: a preimage to
-$K^{(I)}$ is $A^{(I)}$. To show that the embedding is full, we only have
-to show that it is full for free modules, since any object in
-$\text{Mod}_A/\mathcal{T}$ is the cokernel of a morphism between free modules.
+Furthermore, this embedding is essentially surjective: a preimage to an
+$S^{-1}A$-module $N$ is $N_A$, that is $N$ regarded as an $A$-module, since the
+canonical map $N_A \otimes_A S^{-1}A \to N$ which maps $x \otimes a/s$ to
+$(a/s) \cdot x$ is an isomorphism of $S^{-1}A$-modules.
+\end{proof}
 
-\medskip\noindent
-Thus let a $K$-linear map $K^{(I)} \to K^{(J)}$ be given. We can decompose
-this map into a scaling map $K^{(I)} \to K^{(I)}$, $e_i \mapsto d_i^{-1} e_i$
-($d_i \in A$), followed by a map $K^{(I)} \to K^{(J)}$ whose
-(possibly infinite) matrix
-has all entries in $A$. It is then obvious that the second map is induced by an
-$A$-linear map $A^{(I)} \to A^{(J)}$. The scaling map possesses a preimage in
-$\text{Mod}_A/\mathcal{T}$ as well, for it is the inverse to the map
-$A^{(I)} \to A^{(I)}$, $e_i \mapsto d_i$, in $\text{Mod}_A/\mathcal{T}$.
-This map is indeed invertible in $\text{Mod}_A/\mathcal{T}$, since its kernel
-is zero (even before passing to the quotient) and its cokernel is a torsion
-module.
+\begin{proposition}
+\label{proposition-quotient-by-torsion-modules}
+Let $A$ be a ring. Let $Q(A)$ denote its total quotient ring (as in Algebra, Example \ref{algebra-example-localize-at-prime}). Let
+$\text{Mod}_A$ denote the category of $A$-modules and $\mathcal{T}$ its
+Serre subcategory of torsion modules. Let $\text{Mod}_{Q(A)}$ denote the category
+of $Q(A)$-modules. Then there is a canonical equivalence
+$\text{Mod}_A/\mathcal{T} \rightarrow \text{Mod}_{Q(A)}$.
+\end{proposition}
+
+\begin{proof}
+Follows immediately from applying Proposition
+\ref{proposition-localization-and-serre-quotients} to the multiplicative subset
+$S = \{f \in A \mid f \text{ is not a zerodivisor in }A\}$, since a module is a
+torsion module if and only if all of its elements are each annihilated by some
+element of $S$.
 \end{proof}
 
 \begin{proposition}


### PR DESCRIPTION
This commit formulates the statement in question more generally and, simultaneously, significantly streamlines the proof. The new formulation of `proposition-quotient-by-torsion-modules` is strictly more general than the previous one, so I don't think that there are any issues with our desired permanency of tags! (I was the original author of that subsection and am sorry for potentially leading some people astray.)