### PR TITLE
Snake lemma

### DIFF
--- a/algebra.tex
+++ b/algebra.tex
@@ -290,40 +290,53 @@ it is equal to $R_\mathfrak p/\mathfrak pR_\mathfrak p
 \noindent
 The snake lemma and its variants are discussed in the setting of
 abelian categories in
-Homology, Section \ref{homology-section-abelian-categories}.
+Homology, Section \ref{homology-section-abelian-categories}. \\
+We start with a basic remark.
+
+\begin{remark}
+\label{remark-induced-hom-between-ker-and-coker}
+	Given a commutative diagram of abelian groups
+$$
+\xymatrix{
+X \ar[r]^f \ar[d]_{\alpha} & Y \ar[d]^{\beta} \\
+U \ar[r]_g & V
+}
+$$
+, f induces a homomorphism $\Ker(\alpha) \rightarrow \Ker(\beta)$. Indeed, if $x$ is an element of $\Ker(\alpha)$, then $f(x)$ is an element of $\Ker(\beta)$ since $\beta(f(x)) = g(\alpha(x)) = g(0) = 0$. \\
+Moreover, $g$ induces a homomorphism $\Coker(\alpha) \rightarrow \Coker(\beta)$. Indeed, if $\overline{u}$ is an element of $\Coker(\alpha)$, then $\overline{g(u)}$ is an element of $\Coker(\beta)$ that does not depend on the choice of the representative $u$, and the induced map is easily checked to be a homomorphism. \\
+Finally, note that $\Ker(\alpha) \rightarrow \Ker(\beta)$ (resp. $\Coker(\alpha) \rightarrow \Coker(\beta)$) is injective (resp. surjective) whenever $f$ (resp. $g$) is so.
+\end{remark}
 
 \begin{lemma}
 \label{lemma-snake}
 \begin{reference}
-\cite[III, Lemma 3.3]{Cartan-Eilenberg}
+\cite[III, Lemma 3.3]{Cartan-Eilenberg} or \cite[III, Lemma 9.1]{LangAlg}
 \end{reference}
 Suppose given a commutative diagram
 $$
 \xymatrix{
-& X \ar[r] \ar[d]^\alpha &
-Y \ar[r] \ar[d]^\beta &
+& X \ar[r]^f \ar[d]^\alpha &
+Y \ar[r]^h \ar[d]^\beta &
 Z \ar[r] \ar[d]^\gamma &
 0 \\
-0 \ar[r] & U \ar[r] & V \ar[r] & W
+0 \ar[r] & U \ar[r]_g & V \ar[r]_i & W
 }
 $$
-of abelian groups with exact rows, then there is a canonical exact sequence
+of abelian groups with exact rows (a so-called snake diagram), then there is a canonical exact sequence
 $$
 \Ker(\alpha) \to \Ker(\beta) \to \Ker(\gamma)
 \to
 \Coker(\alpha) \to \Coker(\beta) \to \Coker(\gamma)
 $$
-Moreover, if $X \to Y$ is injective, then the first map is
-injective, and if $V \to W$ is surjective, then the last
+. Moreover, if $f$ is injective, then the first map is
+injective, and if $i$ is surjective, then the last
 map is surjective.
 \end{lemma}
 
 \begin{proof}
 The map $\partial : \Ker(\gamma) \to \Coker(\alpha)$ is defined
-as follows. Take $z \in \Ker(\gamma)$. Choose $y \in Y$ mapping to $z$.
-Then $\beta(y) \in V$ maps to zero in $W$. Hence $\beta(y)$ is the image of
-some $u \in U$. Set $\partial z = \overline{u}$ the class of $u$ in the
-cokernel of $\alpha$. Proof of exactness is omitted.
+as follows. Take $z \in \Ker(\gamma)$. From the exactness of the upper row it follows that $h$ is surjective, so choose some $y \in Y$ mapping to $z$. Then $\beta(y) \in V$ maps to zero in $W$. Hence, $\beta(y)$ is the image of a unique $u \in U$ by the exactness of the lower row. Set $\partial z = \overline{u}$ the class of $u$ in the
+cokernel of $\alpha$. Using the exactness of both rows, one can check that $\partial z$ is independent of $y$, thus $\partial$ is well-defined. Moreover, $\partial$ is a homomorphism, and we omit the proof of exactness that consists in chasing diagrams.
 \end{proof}
 
 

--- a/algebra.tex
+++ b/algebra.tex
@@ -310,7 +310,7 @@ Finally, note that $\Ker(\alpha) \rightarrow \Ker(\beta)$ (resp. $\Coker(\alpha)
 \begin{lemma}
 \label{lemma-snake}
 \begin{reference}
-\cite[III, Lemma 3.3]{Cartan-Eilenberg} or \cite[III, Lemma 9.1]{LangAlg}
+\cite[III, Lemma 3.3]{Cartan-Eilenberg} or \cite[III, Lemma 9.1]{Lang}
 \end{reference}
 Suppose given a commutative diagram
 $$


### PR DESCRIPTION
As suggested in the todo-list we add a little "bit more to the section on the snake lemma in algebra.tex". 
In particular, we add a remark and a new reference before the lemma itself, and we improve the logical structure of the proof by making more explicit where one uses the assumptions, while keeping the proof not verbose.