### PR TITLE
Small remark on when the composition of adjoints is isomorphic to the identity

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -3157,6 +3157,16 @@ faithful, as $v$ defines an inverse on morphism sets.
 Part (2) is dual to part (1).
 \end{proof}
 
+\begin{remark}
+\label{remark-composition-of-adjoints-isomorphic-to-identity}
+The proof of Lemma \ref{lemma-adjoint-fully-faithful} shows that, in the
+situation of Definition \ref{definition-adjoint}, the composition $v \circ u$
+is isomorphic to the identity via \emph{some} natural isomorphism if and only
+if the unit is a natural isomorphism. Dually, the composition $u \circ v$ is
+isomorphic to the identity via some natural isomorphism if and only if the
+counit is a natural isomorphism.
+\end{remark}
+
 \begin{lemma}
 \label{lemma-adjoint-exact}
 Let $u$ be a left adjoint to $v$ as in Definition \ref{definition-adjoint}.


### PR DESCRIPTION
This remark is stated as Proposition 2.5 over at the [nLab](https://ncatlab.org/nlab/show/adjoint+functor), with a more fancy proof. I quite like that proof, but I think it's good to also have the pedestrian proof available.