### PR TITLE
Add details to proof regarding fully faithfulness of left adjoint

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -3150,8 +3150,14 @@ By adjointness this corresponds to a morphism $u(X') \to u(X)$. By fully
 faithfulness of $u$ this corresponds to a morphism $X' \to X$. Thus we
 see that $X \to v(u(X))$ defines a bijection
 $\Mor(X', X) \to \Mor(X', v(u(X)))$. Hence it is an isomorphism.
-Conversely, if $\text{id} \cong v \circ u$ then $u$ has to be fully
-faithful, as $v$ defines an inverse on morphism sets.
+Conversely, if $\varphi : \text{id} \to v \circ u$ is a natural isomorphism, then $u$
+is faithful for the trivial reason that the composition $\Mor(X,X') \to
+\Mor(u(X),u(X')) \to \Mor(v(u(X)),v(u(X')))$ is a bijection. Furthermore, $u$
+is full: A preimage for a morphism $\gamma : u(X) \to u(X')$ is
+$u(\varphi_{X'}^{-1} \circ v(\varepsilon_{u(X')} \circ u(\varphi_{X'}) \circ
+\gamma) \circ \eta_X)$, where $\eta : \text{id}_C \to v \circ u$ is the
+unit and $\varepsilon : u \circ v \to \text{id}_D$ is the counit of the
+adjunction.
 
 \medskip\noindent
 Part (2) is dual to part (1).


### PR DESCRIPTION
Unless I overlooked something, which might well be possible, the current proof of Tag 07RB is incomplete. This pull request adds the missing part.

Should we explain how one can check that the morphism given in my commit is indeed a preimage? This can be done using the triangle identities (but we don't seem to have these covered) or very nicely using string diagrams.