### PR TITLE
Upgrade links to https where possible

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -355,7 +355,7 @@ The Free Software Foundation may publish new, revised versions
 of the GNU Free Documentation License from time to time.  Such new
 versions will be similar in spirit to the present version, but may
 differ in detail to address new problems or concerns.  See
-http://www.gnu.org/copyleft/.
+https://www.gnu.org/copyleft/.
 
 Each version of the License is given a distinguishing version number.
 If the Document specifies that a particular numbered version of this

--- a/README
+++ b/README
@@ -4,7 +4,7 @@
 Collaborative web-based project writing a text book on algebraic stacks and the
 algebraic geometry that is needed to define them. Location on the web:
 
-	http://stacks.math.columbia.edu/
+	https://stacks.math.columbia.edu/
 
 You can simply latex the files in the current directory read them, edit them,
 and submit your changes by email back into the project.

--- a/crystalline.tex
+++ b/crystalline.tex
@@ -4921,7 +4921,7 @@ Divided Power Algebra, Lemma \ref{dpa-lemma-nil},
 we cannot conclude that $I^n = 0$ for some $n$. A counter example
 is $\mathbf{F}_p\langle x \rangle$. To prove it in general when
 $\mathcal{F} = \mathcal{O}_{X/S}$ the argument of
-\url{http://math.columbia.edu/~dejong/wordpress/?p=2227}
+\url{https://math.columbia.edu/~dejong/wordpress/?p=2227}
 works. When the coefficients $\mathcal{F}$ are non-trivial the
 argument of \cite{Faltings-very} seems to be as follows. Reduce to the
 case $pA = 0$ by More on Algebra, Lemma

--- a/documentation/git-howto
+++ b/documentation/git-howto
@@ -100,8 +100,8 @@ More information
 
 There is a lot more you can do with git. For example you can set it up so that
 the maintainer of the stacks project can pull changes directly from your own
-repository. To learn more see http://git-scm.com and
-http://www.kernel.org/pub/software/scm/git/docs/
+repository. To learn more see https://git-scm.com and
+https://www.kernel.org/pub/software/scm/git/docs/
 
 Do assign labels to new theorems, propositions, etc., but don't bother to
 assign tags.

--- a/documentation/submitting-patches
+++ b/documentation/submitting-patches
@@ -23,7 +23,7 @@ Email the patchfile. Please include PATCH in the subject line.
 (3) Nontrivial method: Create a patch for the whole project,
 especially useful if you are editing multiple files. To do this you can use the
 following steps.
-	(3a) Install git, see http://git-scm.com
+	(3a) Install git, see https://git-scm.com
 	(3b) Clone the project. Type
 		git clone git://github.com/stacks/stacks-project.git
 	(3c) Change into the stacks directory. Run make, edit files, etc.

--- a/examples-stacks.tex
+++ b/examples-stacks.tex
@@ -1045,7 +1045,7 @@ which recovers $(X_i, \varphi_{ij})$. The technique of the proof of
 Bootstrap, Lemma \ref{bootstrap-lemma-descent-torsor}
 reduces this to a set theoretical question, so the reader who ignores
 set theoretical questions will ``know'' that the result is true. In
-\url{http://math.columbia.edu/~dejong/wordpress/?p=591}
+\url{https://math.columbia.edu/~dejong/wordpress/?p=591}
 there is a suggestion as to how to approach this problem.
 \end{remark}
 

--- a/examples.tex
+++ b/examples.tex
@@ -3271,7 +3271,7 @@ surjective in general.
 \noindent
 In this section we briefly describe an example due to Brian Conrad.
 You can find the example online at
-\href{http://mathoverflow.net/questions/15082/fpqc-covers-of-stacks/15269#15269}{this location}.
+\href{https://mathoverflow.net/questions/15082/fpqc-covers-of-stacks/15269#15269}{this location}.
 Our example is slightly different.
 
 \medskip\noindent

--- a/fdl.tex
+++ b/fdl.tex
@@ -426,7 +426,7 @@ The Free Software Foundation may publish new, revised versions
 of the GNU Free Documentation License from time to time.  Such new
 versions will be similar in spirit to the present version, but may
 differ in detail to address new problems or concerns.  See
-http://www.gnu.org/copyleft/.
+https://www.gnu.org/copyleft/.
 
 Each version of the License is given a distinguishing version number.
 If the Document specifies that a particular numbered version of this

--- a/hypercovering.tex
+++ b/hypercovering.tex
@@ -62,7 +62,7 @@ over $X$ is computed by the colimit of the {\v C}ech cohomology groups.
 A more general gadget one can consider is a simplicial augmentation where
 one has cohomological descent, see \cite[Expos\'e Vbis]{SGA4}. A nice
 manuscript on cohomological descent is the text by Brian Conrad, see
-\url{http://math.stanford.edu/~conrad/papers/hypercover.pdf}.
+\url{https://math.stanford.edu/~conrad/papers/hypercover.pdf}.
 We will come back to these issue in the chapter on simplicial spaces
 where we will show, for example, that proper hypercoverings of
 ``locally compact'' topological spaces are of cohomological

--- a/introduction.tex
+++ b/introduction.tex
@@ -66,7 +66,7 @@ sections with historical remarks for each and every chapter.
 \medskip\noindent
 Those who contributed to this work are listed on the title page of the book
 version of this work and
-\href{http://stacks.math.columbia.edu/tex/CONTRIBUTORS}{online}.
+\href{https://stacks.math.columbia.edu/tex/CONTRIBUTORS}{online}.
 Here we would like to name a selection of major contributions:
 \begin{enumerate}
 \item Jarod Alper wrote
@@ -84,7 +84,7 @@ Descent, Section \ref{descent-section-descent-universally-injective}.
 \item the chapter \hyperref[fields-section-phantom]{Fields}
 \end{enumerate}
 are from
-\href{http://people.fas.harvard.edu/~amathew/cr.html}{The CRing Project},
+\href{https://people.fas.harvard.edu/~amathew/cr.html}{The CRing Project},
 courtesy of Akhil Mathew et al.
 \item Alex Perry wrote the material on projective modules,
 Mittag-Leffler modules, including the proof of

--- a/morphisms.tex
+++ b/morphisms.tex
@@ -9284,7 +9284,7 @@ Thus $Z \to S$ is a proper (Lemma \ref{lemma-image-proper-is-proper}).
 
 \noindent
 The proof of the following lemma is due to Bjorn Poonen, see
-\href{http://mathoverflow.net/questions/23337/is-a-universally-closed-morphism-of-schemes-quasi-compact/23528#23528}{this location}.
+\href{https://mathoverflow.net/questions/23337/is-a-universally-closed-morphism-of-schemes-quasi-compact/23528#23528}{this location}.
 
 \begin{lemma}
 \label{lemma-universally-closed-quasi-compact}

--- a/my.bib
+++ b/my.bib
@@ -123,7 +123,7 @@
       YEAR = {2014},
     NUMBER = {4},
      PAGES = {489--531},
-       URL = {http://dx.doi.org/10.14231/AG-2014-022},
+       URL = {https://dx.doi.org/10.14231/AG-2014-022},
 }
 
 @ARTICLE{alper_quotient,
@@ -167,7 +167,7 @@
       YEAR = {2006},
     NUMBER = {1},
      PAGES = {37--56},
-       URL = {http://dx.doi.org/10.1007/s00229-005-0602-1},
+       URL = {https://dx.doi.org/10.1007/s00229-005-0602-1},
 }
 
 @ARTICLE{AokiHomStacksErr,
@@ -178,7 +178,7 @@
       YEAR = {2006},
     NUMBER = {1},
      PAGES = {135},
-       URL = {http://dx.doi.org/10.1007/s00229-006-0029-3},
+       URL = {https://dx.doi.org/10.1007/s00229-006-0029-3},
 }
 
 @ARTICLE{Arabia,
@@ -363,7 +363,7 @@
      PAGES = {385--437},
  PUBLISHER = {Springer, New York},
       YEAR = {1989},
-       URL = {http://dx.doi.org/10.1007/978-1-4613-9649-9_7},
+       URL = {https://dx.doi.org/10.1007/978-1-4613-9649-9_7},
 }
 
 @INCOLLECTION{Artin-Lipman,
@@ -412,7 +412,7 @@
       YEAR = {1962},
      PAGES = {116--125},
       ISSN = {0002-9327},
-       URL = {http://dx.doi.org/10.2307/2372807},
+       URL = {https://dx.doi.org/10.2307/2372807},
 }
 
 @ARTICLE{Auslander,
@@ -456,7 +456,7 @@
       YEAR = {1940},
      PAGES = {800--806},
       ISSN = {0002-9904},
-       URL = {http://dx.doi.org/10.1090/S0002-9904-1940-07306-9},
+       URL = {https://dx.doi.org/10.1090/S0002-9904-1940-07306-9},
 }
 
 @INPROCEEDINGS{Barlet,
@@ -519,7 +519,7 @@
       YEAR = {2013},
     NUMBER = {5-6},
      PAGES = {173--175},
-       URL = {http://dx.doi.org/10.1016/j.crma.2013.03.00},
+       URL = {https://dx.doi.org/10.1016/j.crma.2013.03.004},
 }
 
 @UNPUBLISHED{Beheshti,
@@ -613,7 +613,7 @@
 @UNPUBLISHED{stacks_book,
 	AUTHOR = {Behrend, Kai and Conrad, Brian and Edidin, Dan and Fantechi, Barbara and Fulton, William and G{\"o}ttsche, Lothar and Kresch, Andrew},
 	TITLE = {Algebraic stacks},
-	URL = {http://www.math.uzh.ch/index.php?pr_vo_det&key1=1287&key2=580&no_cache=1},
+	URL = {https://www.math.uzh.ch/index.php?pr_vo_det&key1=1287&key2=580&no_cache=1},
 	YEAR = {2007},
 }
 
@@ -634,7 +634,7 @@
      TITLE = {Quantization of Hitchin's integrable system and Hecke eigensheaves},
       NOTE = {preprint},
      PAGES = {384},
-       URL = {http://www.math.uchicago.edu/~mitya/langlands/hitchin/BD-hitchin.pdf},
+       URL = {https://www.math.uchicago.edu/~mitya/langlands/hitchin/BD-hitchin.pdf},
 }
 
 @ARTICLE{Beilinson,
@@ -796,7 +796,7 @@
  PUBLISHER = {Springer-Verlag, New York},
       YEAR = {1991},
      PAGES = {xii+288},
-       URL = {http://dx.doi.org/10.1007/978-1-4612-0941-6},
+       URL = {https://dx.doi.org/10.1007/978-1-4612-0941-6},
 }
 
 @ARTICLE{bcs,
@@ -935,7 +935,7 @@
       PAGES       = {73 -- 75},
 }
 % this seems to be wrong:
-% http://www.zentralblatt-math.org/zmath/en/search/?q=an:0011.14504&format=complete
+% https://www.zentralblatt-math.org/zmath/en/search/?q=an:0011.14504&format=complete
 % it's M. Artin in the title, but either it was written in 1935 and it's Emil
 % (Chevalley being really young), or it is (probably) Michael Artin and it's 1975.
 %
@@ -1010,21 +1010,21 @@
       TITLE       = {Die {B}rauersche {G}ruppe; ihre {V}erallgemeinerungen und {A}nwendungen in der {A}rithmetischen {G}eometrie},
       YEAR        = {2001},
       NOTE        = {preprint},
-      URL         = {http://www.math.u-psud.fr/~colliot/liste-prepub.html},
+      URL         = {https://www.math.u-psud.fr/~colliot/liste-prepub.html},
 }
 % it's not really a preprint I think
 
 @ARTICLE{conrad,
   AUTHOR = {Conrad, Brian},
   TITLE = {Keel-Mori theorem via stacks},
-  URL = {http://www.math.lsa.umich.edu/~bdconrad/papers/coarsespace.pdf},
+  URL = {https://math.stanford.edu/~conrad/papers/coarsespace.pdf},
   YEAR = {2005},
 }
 
 @ARTICLE{conrad_gaga,
   AUTHOR = {Conrad, Brian},
   TITLE = {Formal GAGA for Artin stacks},
-  URL = {http://math.stanford.edu/~conrad/papers/formalgaga.pdf},
+  URL = {https://math.stanford.edu/~conrad/papers/formalgaga.pdf},
   YEAR = {2005},
 }
 
@@ -1036,7 +1036,7 @@
  PUBLISHER = {Springer-Verlag, Berlin},
       YEAR = {2000},
      PAGES = {vi+296},
-       URL = {http://dx.doi.org/10.1007/b75857},
+       URL = {https://dx.doi.org/10.1007/b75857},
 }
 
 @ARTICLE{Conrad-Nagata,
@@ -1072,7 +1072,7 @@
       YEAR = {2007},
     NUMBER = {2},
      PAGES = {209--278},
-       URL = {http://dx.doi.org/10.1017/S1474748006000089},
+       URL = {https://dx.doi.org/10.1017/S1474748006000089},
 }
 
 @ARTICLE{CLO,
@@ -1479,7 +1479,7 @@
       YEAR = {1996},
     NUMBER = {1},
      PAGES = {267--271},
-       URL = {http://dx.doi.org/10.1016/0040-9383(94)00056-5},
+       URL = {https://dx.doi.org/10.1016/0040-9383(94)00056-5},
 }
 
 @BOOK{Engelking,
@@ -1520,7 +1520,7 @@
       YEAR = {1981},
     NUMBER = {1},
      PAGES = {45--56},
-       URL = {http://dx.doi.org/10.1007/BF01450555},
+       URL = {https://dx.doi.org/10.1007/BF01450555},
 }
 
 @ARTICLE{Faltings-kriterium,
@@ -1532,7 +1532,7 @@
     NUMBER = {3},
      PAGES = {393--401},
       ISSN = {0020-9910},
-       URL = {http://dx.doi.org/10.1007/BF01394251},
+       URL = {https://dx.doi.org/10.1007/BF01394251},
 }
 
 @ARTICLE{Faltings-some,
@@ -1544,7 +1544,7 @@
     NUMBER = {3},
      PAGES = {721--737},
       ISSN = {0034-5318},
-       URL = {http://dx.doi.org/10.2977/prims/1195186927},
+       URL = {https://dx.doi.org/10.2977/prims/1195186927},
 }
 
 @ARTICLE{Faltings-contribution,
@@ -1555,7 +1555,7 @@
       YEAR = {1980},
      PAGES = {99--106},
       ISSN = {0027-7630},
-       URL = {http://projecteuclid.org/euclid.nmj/1118786022},
+       URL = {https://projecteuclid.org/euclid.nmj/1118786022},
 }
 
 @ARTICLE{Faltings-uber,
@@ -1566,7 +1566,7 @@
       YEAR = {1980},
      PAGES = {43--51},
       ISSN = {0075-4102},
-       URL = {http://dx.doi.org/10.1515/crll.1980.313.43},
+       URL = {https://dx.doi.org/10.1515/crll.1980.313.43},
 }
 
 @ARTICLE{Faltings-algebraisation,
@@ -1578,7 +1578,7 @@
     NUMBER = {3},
      PAGES = {501--514},
       ISSN = {0003-486X},
-       URL = {http://dx.doi.org/10.2307/1971235},
+       URL = {https://dx.doi.org/10.2307/1971235},
 }
 
 @ARTICLE{Faltings-erganzungen,
@@ -1590,7 +1590,7 @@
     NUMBER = {1},
      PAGES = {31--33},
       ISSN = {0003-889X},
-       URL = {http://dx.doi.org/10.1007/BF01238465},
+       URL = {https://dx.doi.org/10.1007/BF01238465},
 }
 
 @ARTICLE{Faltings-Macaulayfizierung,
@@ -1602,7 +1602,7 @@
     NUMBER = {2},
      PAGES = {175--192},
       ISSN = {0025-5831},
-       URL = {http://dx.doi.org/10.1007/BF01424774},
+       URL = {https://dx.doi.org/10.1007/BF01424774},
 }
 
 @ARTICLE{Faltings-dualizing,
@@ -1613,7 +1613,7 @@
       YEAR = {1978},
     NUMBER = {1},
      PAGES = {75--86},
-       URL = {http://dx.doi.org/10.1007/BF01437825},
+       URL = {https://dx.doi.org/10.1007/BF01437825},
 }
 
 @ARTICLE{Faltings-annulators,
@@ -1833,11 +1833,11 @@
       YEAR = {1981},
     NUMBER = {243},
      PAGES = {vi+165},
-       URL = {http://dx.doi.org/10.1090/memo/0243},
+       URL = {https://dx.doi.org/10.1090/memo/0243},
 }
 
 @ARTICLE{FDL,
-    URL = {http://www.gnu.org/licenses/fdl.html},
+    URL = {https://www.gnu.org/licenses/fdl.html},
 }
 
 %%%%%%%%%%%%%%%%%%%%%% G %%%%%%%%%%%%%%%%%%%%%%
@@ -1850,7 +1850,7 @@
       YEAR = {1994},
     NUMBER = {1-3},
      PAGES = {325--335},
-       URL = {http://dx.doi.org/10.1007/BF02773001},
+       URL = {https://dx.doi.org/10.1007/BF02773001},
 }
 
 @ARTICLE{gabber-nonexcellent,
@@ -1861,7 +1861,7 @@
       YEAR = {1996},
     NUMBER = {4},
      PAGES = {543--546},
-       URL = {http://dx.doi.org/10.1007/BF02567973},
+       URL = {https://dx.doi.org/10.1007/BF02567973},
 }
 
 @BOOK{GZ,
@@ -1976,7 +1976,7 @@
     NUMBER = {3},
      PAGES = {425--443},
       ISSN = {0002-9327},
-       URL = {http://muse.jhu.edu/journals/american_journal_of_mathematics/v123/123.3goodwillie.pdf},
+       URL = {https://muse.jhu.edu/journals/american_journal_of_mathematics/v123/123.3goodwillie.pdf},
 }
 
 @INCOLLECTION{GE,
@@ -2073,7 +2073,7 @@
       YEAR = {1981},
     NUMBER = {2},
      PAGES = {445--465},
-       URL = {http://dx.doi.org/10.2307/1999336},
+       URL = {https://dx.doi.org/10.2307/1999336},
 }
 
 @ARTICLE{Greenlees-May,
@@ -2336,7 +2336,7 @@
     VOLUME = {722},
       YEAR = {2017},
      PAGES = {137--182},
-       URL = {http://dx.doi.org/10.1515/crelle-2014-0057},
+       URL = {https://dx.doi.org/10.1515/crelle-2014-0057},
 }
 
 @ARTICLE{Hall-Rydh,
@@ -2552,7 +2552,7 @@
       YEAR = {2007},
     NUMBER = {1},
      PAGES = {203--214},
-       URL = {http://dx.doi.org/10.1216/rmjm/1181069326},
+       URL = {https://dx.doi.org/10.1216/rmjm/1181069326},
 }
 
 @INCOLLECTION{Heinzer-Rotthaus-Wiegand,
@@ -2572,7 +2572,7 @@
       YEAR = {1982},
     NUMBER = {1},
      PAGES = {145--148},
-       URL = {http://dx.doi.org/10.1216/RMJ-1982-12-1-145},
+       URL = {https://dx.doi.org/10.1216/RMJ-1982-12-1-145},
 }
 
 @ARTICLE{Heitmann-isolated,
@@ -2583,7 +2583,7 @@
       YEAR = {1994},
     NUMBER = {2},
      PAGES = {538--567},
-       URL = {http://dx.doi.org/10.1006/jabr.1994.1031},
+       URL = {https://dx.doi.org/10.1006/jabr.1994.1031},
 }
 
 @ARTICLE{Heitmann-completion-UFD,
@@ -2594,7 +2594,7 @@
       YEAR = {1993},
     NUMBER = {1},
      PAGES = {379--387},
-       URL = {http://dx.doi.org/10.2307/2154327},
+       URL = {https://dx.doi.org/10.2307/2154327},
 }
 
 @ARTICLE{Hir,
@@ -2632,7 +2632,7 @@
  PUBLISHER = {ProQuest LLC, Ann Arbor, MI},
       YEAR = {1967},
      PAGES = {116},
-       URL = {http://gateway.proquest.com/openurl?url_ver=Z39.88-2004&rft_val_fmt=info:ofi/fmt:kev:mtx:dissertation&res_dat=xri:pqdiss&rft_dat=xri:pqdiss:6802486},
+       URL = {https://gateway.proquest.com/openurl?url_ver=Z39.88-2004&rft_val_fmt=info:ofi/fmt:kev:mtx:dissertation&res_dat=xri:pqdiss&rft_dat=xri:pqdiss:6802486},
 }
 
 @ARTICLE{Hochster-loci,
@@ -2662,7 +2662,7 @@
 	MONTH = {1},
 	VOLUME = {163},
 	PAGES = {93--124},
-	EPRINT	= {http://arxiv.org/pdf/math/0110247},
+	EPRINT	= {https://arxiv.org/pdf/math/0110247},
 }
 
 @ARTICLE{Hoobler-finite,
@@ -2697,7 +2697,7 @@
       YEAR = {1993},
     NUMBER = {3},
      PAGES = {455--477},
-       URL = {http://dx.doi.org/10.1007/BF02571668},
+       URL = {https://dx.doi.org/10.1007/BF02571668},
 }
 
 @ARTICLE{Huber-henselian,
@@ -2738,7 +2738,7 @@
  PUBLISHER = {Friedr. Vieweg \& Sohn, Braunschweig},
       YEAR = {1997},
      PAGES = {xiv+269},
-       URL = {http://dx.doi.org/10.1007/978-3-663-11624-0},
+       URL = {https://dx.doi.org/10.1007/978-3-663-11624-0},
 }
 
 %%%%%%%%%%%%%%%%%%%%%% I %%%%%%%%%%%%%%%%%%%%%%
@@ -2873,7 +2873,7 @@
       YEAR = {1997},
     NUMBER = {2},
      PAGES = {481--527},
-       URL = {http://dx.doi.org/10.1090/S0002-9947-97-01616-4},
+       URL = {https://dx.doi.org/10.1090/S0002-9947-97-01616-4},
 }
 
 @ARTICLE{janelidze-tholen,
@@ -2960,7 +2960,7 @@
       YEAR = {2011},
      PAGES = {1--85},
       ISSN = {0073-8301},
-       URL = {http://dx.doi.org/10.1007/s10240-011-0035-1},
+       URL = {https://dx.doi.org/10.1007/s10240-011-0035-1},
 }
 
 @ARTICLE{dJS,
@@ -2998,7 +2998,7 @@
     NUMBER = {2},
      PAGES = {341--360},
       ISSN = {0021-8693},
-       URL = {http://dx.doi.org/10.1016/j.jalgebra.2004.09.012},
+       URL = {https://dx.doi.org/10.1016/j.jalgebra.2004.09.012},
 }
 
 @BOOK{Jou,
@@ -3028,7 +3028,7 @@
       YEAR = {1996},
     NUMBER = {3},
      PAGES = {1035--1049},
-       URL = {http://dx.doi.org/10.1080/00927879608825619},
+       URL = {https://dx.doi.org/10.1080/00927879608825619},
 }
 
 %%%%%%%%%%%%%%%%%%%%%% K %%%%%%%%%%%%%%%%%%%%%%
@@ -3091,7 +3091,7 @@
      PAGES = {241--253},
  PUBLISHER = {Amer. Math. Soc., Providence, RI},
       YEAR = {1986},
-       URL = {http://dx.doi.org/10.1090/conm/055.1/862638},
+       URL = {https://dx.doi.org/10.1090/conm/055.1/862638},
 }
 
 @BOOK{KatzMazur,
@@ -3143,7 +3143,7 @@
       YEAR = {2002},
     NUMBER = {1},
      PAGES = {123--149 (electronic)},
-       URL = {http://dx.doi.org/10.1090/S0002-9947-01-02817-3},
+       URL = {https://dx.doi.org/10.1090/S0002-9947-01-02817-3},
 }
 
 @BOOK{Kedlaya-Liu-I,
@@ -3243,7 +3243,7 @@
       YEAR = {2010},
     NUMBER = {3},
      PAGES = {641--668},
-       URL = {http://dx.doi.org/10.1007/s00208-009-0409-6},
+       URL = {https://dx.doi.org/10.1007/s00208-009-0409-6},
 }
 
 @ARTICLE{Kiehl,
@@ -3453,7 +3453,7 @@
     NUMBER = {1},
      PAGES = {1--31},
       ISSN = {1558-8599},
-       URL = {http://dx.doi.org/10.4310/PAMQ.2016.v12.n1.a1},
+       URL = {https://dx.doi.org/10.4310/PAMQ.2016.v12.n1.a1},
 }
 
 @BOOK{KZ,
@@ -3545,7 +3545,7 @@
  PUBLISHER = {Friedr. Vieweg \& Sohn, Braunschweig},
       YEAR = {1986},
      PAGES = {viii+402},
-       URL = {http://dx.doi.org/10.1007/978-3-663-14074-0},
+       URL = {https://dx.doi.org/10.1007/978-3-663-14074-0},
 }
 
 @ARTICLE{Kunz-flat,
@@ -3695,7 +3695,7 @@
      PAGES = {241--247},
  PUBLISHER = {Springer, Berlin},
       YEAR = {1986},
-       URL = {http://dx.doi.org/10.1007/BFb0075463},
+       URL = {https://dx.doi.org/10.1007/BFb0075463},
 }
 
 @INCOLLECTION{Lech-YAPO,
@@ -3707,7 +3707,7 @@
      PAGES = {248--249},
  PUBLISHER = {Springer, Berlin},
       YEAR = {1986},
-       URL = {http://dx.doi.org/10.1007/BFb0075464},
+       URL = {https://dx.doi.org/10.1007/BFb0075464},
 }
 
 @ARTICLE{LLPY,
@@ -3718,14 +3718,14 @@
       YEAR = {2001},
     NUMBER = {11},
      PAGES = {3193--3200},
-       URL = {http://dx.doi.org/10.1090/S0002-9939-01-05962-7},
+       URL = {https://dx.doi.org/10.1090/S0002-9939-01-05962-7},
 }
 
 @MISC{Lenstra,
 	AUTHOR = {Lenstra, Hendrik Willem},
 	TITLE = {Galois theory for schemes},
 	PAGES = {1--109},
-	URL = {http://websites.math.leidenuniv.nl/algebra/GSchemes.pdf},
+	URL = {https://websites.math.leidenuniv.nl/algebra/GSchemes.pdf},
 }
 
 @ARTICLE{Lichtenbaum-Schlessinger,
@@ -3811,7 +3811,7 @@
      PAGES = {1--259},
  PUBLISHER = {Springer, Berlin},
       YEAR = {2009},
-       URL = {http://dx.doi.org/10.1007/978-3-540-85420-3},
+       URL = {https://dx.doi.org/10.1007/978-3-540-85420-3},
 }
 
 @BOOK{Liu,
@@ -3834,7 +3834,7 @@
       YEAR = {2003},
     NUMBER = {1},
      PAGES = {221--228},
-       URL = {http://dx.doi.org/10.1016/S0021-8693(03)00239-4},
+       URL = {https://dx.doi.org/10.1016/S0021-8693(03)00239-4},
 }
 
 @ARTICLE{lundkvist-skjelnes,
@@ -3852,7 +3852,7 @@
 	AUTHOR = {Lurie, Jacob},
 	TITLE = {Derived Algebraic Geometry},
 	YEAR = {2004},
-	URL = {http://hdl.handle.net/1721.1/30144},
+	URL = {https://hdl.handle.net/1721.1/30144},
 }
 
 @BOOK{lurie_topos,
@@ -3871,42 +3871,42 @@
     AUTHOR = {Lurie, Jacob},
   TITLE = {Derived Algebraic Geometry {I}: Stable Infinity Categories},
   YEAR = {2009},
-  URL = {http://www-math.mit.edu/~lurie/papers/DAG-I.pdf},
+  URL = {http://www.math.harvard.edu/~lurie/papers/DAG-I.pdf},
 }
 
 @ARTICLE{dag2,
   AUTHOR = {Lurie, Jacob},
   TITLE = {Derived Algebraic Geometry {II}: Noncommutative Algebra},
   YEAR = {2009},
-  URL = {http://www-math.mit.edu/~lurie/papers/DAG-II.pdf},
+  URL = {http://www.math.harvard.edu/~lurie/papers/DAG-II.pdf},
 }
 
 @ARTICLE{dag3,
   AUTHOR = {Lurie, Jacob},
   TITLE = {Derived Algebraic Geometry {III}: Commutative Algebra},
   YEAR = {2009},
-  URL = {http://www-math.mit.edu/~lurie/papers/DAG-III.pdf},
+  URL = {http://www.math.harvard.edu/~lurie/papers/DAG-III.pdf},
 }
 
 @ARTICLE{dag4,
   AUTHOR = {Lurie, Jacob},
   TITLE = {Derived Algebraic Geometry {IV}: Deformation Theory},
   YEAR = {2009},
-  URL = {http://www-math.mit.edu/~lurie/papers/DAG-IV.pdf},
+  URL = {http://www.math.harvard.edu/~lurie/papers/DAG-IV.pdf},
 }
 
 @ARTICLE{dag5,
   AUTHOR = {Lurie, Jacob},
   TITLE = {Derived Algebraic Geometry {V}: Structured Spaces},
   YEAR = {2009},
-  URL = {http://www-math.mit.edu/~lurie/papers/DAG-V.pdf},
+  URL = {http://www.math.harvard.edu/~lurie/papers/DAG-V.pdf},
 }
 
 @ARTICLE{dag12,
   AUTHOR = {Lurie, Jacob},
   TITLE = {Derived Algebraic Geometry {XII}: Proper Morphisms, Completions, and the Grothendieck Existence Theorem},
   YEAR = {2011},
-  URL = {http://www-math.mit.edu/~lurie/papers/DAG-XII.pdf},
+  URL = {http://www.math.harvard.edu/~lurie/papers/DAG-XII.pdf},
 }
 % continue with the DAG series? it goes all the way to XIV for now
 
@@ -3918,7 +3918,7 @@
       YEAR = {1993},
     NUMBER = {1},
      PAGES = {95--111},
-       URL = {http://dx.doi.org/10.1007/BF03026540},
+       URL = {https://dx.doi.org/10.1007/BF03026540},
 }
 
 @ARTICLE{Lyubeznik,
@@ -3995,7 +3995,7 @@
       YEAR = {1957},
      PAGES = {28--29},
       ISSN = {0002-9890},
-       URL = {http://dx.doi.org/10.2307/2309082},
+       URL = {https://dx.doi.org/10.2307/2309082},
 }
 
 @ARTICLE{MP98,
@@ -4016,7 +4016,7 @@
      PAGES = {187--198},
  PUBLISHER = {Amer. Math. Soc., Providence, RI},
       YEAR = {2002},
-       URL = {http://dx.doi.org/10.1090/conm/314/05431},
+       URL = {https://dx.doi.org/10.1090/conm/314/05431},
 }
 
 @ARTICLE{MT,
@@ -4036,7 +4036,7 @@
       YEAR = {1978},
     NUMBER = {1},
      PAGES = {77--112},
-       URL = {http://dx.doi.org/10.1016/0021-8693(78)90176-X},
+       URL = {https://dx.doi.org/10.1016/0021-8693(78)90176-X},
 }
 
 @BOOK{Matsuki,
@@ -4206,7 +4206,7 @@
     NUMBER = {3},
      PAGES = {847--849},
       ISSN = {0002-9327},
-       URL = {http://dx.doi.org/10.2307/2373780},
+       URL = {https://dx.doi.org/10.2307/2373780},
 }
 
 @BOOK{Mum,
@@ -4321,7 +4321,7 @@
       YEAR = {1959},
      PAGES = {328--333},
       ISSN = {0019-2082},
-       URL = {http://projecteuclid.org/euclid.ijm/1255455255},
+       URL = {https://projecteuclid.org/euclid.ijm/1255455255},
 }
 
 @ARTICLE{Nagata-Remarks-Purity,
@@ -4369,7 +4369,7 @@
       YEAR = {1966},
      PAGES = {163--169},
       ISSN = {0023-608X},
-       URL = {http://dx.doi.org/10.1215/kjm/1250524533},
+       URL = {https://dx.doi.org/10.1215/kjm/1250524533},
 }
 
 @ARTICLE{Nak,
@@ -4454,7 +4454,7 @@
     NUMBER = {1},
      PAGES = {51--87},
       ISSN = {2156-2261},
-       URL = {http://dx.doi.org/10.1215/21562261-1503754},
+       URL = {https://dx.doi.org/10.1215/21562261-1503754},
 }
 
 @ARTICLE{Nishimura-few-II,
@@ -4501,7 +4501,7 @@
       YEAR = {1994},
     NUMBER = {1},
      PAGES = {57--84},
-       URL = {http://dx.doi.org/10.1006/jabr.1994.1175},
+       URL = {https://dx.doi.org/10.1006/jabr.1994.1175},
 }
 
 @ARTICLE{Ogoma-example,
@@ -4599,7 +4599,7 @@
     AUTHOR = {Olsson, Martin Christian},
   TITLE = {Course notes for {M}ath 274: {S}tacks, taken by {A}nton {G}eraschenko},
   YEAR = {2007},
-  URL = {http://math.berkeley.edu/~anton/written/Stacks/Stacks.pdf},
+  URL = {https://math.berkeley.edu/~anton/written/Stacks/Stacks.pdf},
 }
 
 @ARTICLE{olsson-starr,
@@ -4621,7 +4621,7 @@
     NUMBER = {107},
       YEAR = {2008},
      PAGES = {109--168},
-       URL = {http://dx.doi.org/10.1007/s10240-008-0011-6},
+       URL = {https://dx.doi.org/10.1007/s10240-008-0011-6},
 }
 
 @ARTICLE{six-II,
@@ -4631,7 +4631,7 @@
     NUMBER = {107},
       YEAR = {2008},
      PAGES = {169--210},
-       URL = {http://dx.doi.org/10.1007/s10240-008-0012-5},
+       URL = {https://dx.doi.org/10.1007/s10240-008-0012-5},
 }
 
 @ARTICLE{Oort,
@@ -4653,7 +4653,7 @@
     NUMBER = {5},
      PAGES = {1361--1381},
       ISSN = {1072-3374},
-       URL = {http://dx.doi.org/10.1007/BF02399195},
+       URL = {https://dx.doi.org/10.1007/BF02399195},
 }
 
 @ARTICLE{Osserman,
@@ -4664,7 +4664,7 @@
       YEAR = {2015},
      PAGES = {52--78},
       ISSN = {0021-8693},
-       URL = {http://dx.doi.org/10.1016/j.jalgebra.2015.04.022},
+       URL = {https://dx.doi.org/10.1016/j.jalgebra.2015.04.022},
 }
 
 @MISC{Osserman-Payne,
@@ -4785,7 +4785,7 @@
       YEAR = {2005},
     NUMBER = {2},
      PAGES = {230--268},
-       URL = {http://dx.doi.org/10.1016/j.ffa.2004.12.001},
+       URL = {https://dx.doi.org/10.1016/j.ffa.2004.12.001},
 }
 
 @INPROCEEDINGS{popescu-global,
@@ -4808,7 +4808,7 @@
     VOLUME = {118},
       YEAR = {1990},
      PAGES = {45--53},
-       URL = {http://projecteuclid.org/getRecord?id=euclid.nmj/1118781592},
+       URL = {https://projecteuclid.org/getRecord?id=euclid.nmj/1118781592},
 }
 
 @ARTICLE{popescu-GNDA,
@@ -4819,7 +4819,7 @@
     VOLUME = {104},
       YEAR = {1986},
      PAGES = {85--115},
-       URL = {http://projecteuclid.org/getRecord?id=euclid.nmj/1118780554},
+       URL = {https://projecteuclid.org/getRecord?id=euclid.nmj/1118780554},
 }
 
 @ARTICLE{popescu-GND,
@@ -4830,7 +4830,7 @@
     VOLUME = {100},
       YEAR = {1985},
      PAGES = {97--126},
-       URL = {http://projecteuclid.org/getRecord?id=euclid.nmj/1118780236},
+       URL = {https://projecteuclid.org/getRecord?id=euclid.nmj/1118780236},
 }
 
 @ARTICLE{Predonzan49,
@@ -4893,7 +4893,7 @@
      PAGES = {246--253},
  PUBLISHER = {Springer, Berlin},
       YEAR = {1989},
-       URL = {http://dx.doi.org/10.1007/BFb0085936},
+       URL = {https://dx.doi.org/10.1007/BFb0085936},
 }
 
 @ARTICLE{Ratliff,
@@ -4986,7 +4986,7 @@
 @MISC{Reinhard,
 	AUTHOR	= {Reinhard, Philipp Michael},
 	TITLE	= {Andre-Quillen homology for simplicial algebras and ring spectra},
-	URL = {http://theses.gla.ac.uk/507/},
+	URL = {https://theses.gla.ac.uk/507/},
 }
 
 @INCOLLECTION{YPGS,
@@ -5094,7 +5094,7 @@
       YEAR = {2007},
     NUMBER = {2},
      PAGES = {201--255},
-       URL = {http://dx.doi.org/10.1090/S1056-3911-06-00461-9},
+       URL = {https://dx.doi.org/10.1090/S1056-3911-06-00461-9},
 }
 
 @ARTICLE{Rotthaus-excellent,
@@ -5106,7 +5106,7 @@
       YEAR = {1990},
     NUMBER = {3},
      PAGES = {455--466},
-       URL = {http://dx.doi.org/10.1007/BF01446905},
+       URL = {https://dx.doi.org/10.1007/BF01446905},
 }
 
 @INCOLLECTION{Rotthaus-Artin,
@@ -5127,7 +5127,7 @@
       YEAR = {2008},
     NUMBER = {2},
      PAGES = {193--256},
-       URL = {http://dx.doi.org/10.1017/is007011012jkt010},
+       URL = {https://dx.doi.org/10.1017/is007011012jkt010},
 }
 
 @ARTICLE{rydh_approx,
@@ -5166,7 +5166,7 @@
       YEAR = {2011},
     NUMBER = {7},
      PAGES = {2632--2646},
-       URL = {http://dx.doi.org/10.1080/00927872.2010.488678},
+       URL = {https://dx.doi.org/10.1080/00927872.2010.488678},
 }
 
 %%%%%%%%%%%%%%%%%%%%%% S %%%%%%%%%%%%%%%%%%%%%%
@@ -5188,7 +5188,7 @@
       YEAR = {1987},
     NUMBER = {6},
      PAGES = {1043--1085},
-       URL = {http://dx.doi.org/10.2307/2374585},
+       URL = {https://dx.doi.org/10.2307/2374585},
 }
 
 @ARTICLE{Saltman-torsion,
@@ -5403,7 +5403,7 @@
     NUMBER = {2},
      PAGES = {459--503},
       ISSN = {0020-9910},
-       URL = {http://dx.doi.org/10.1007/s00222-012-0416-1},
+       URL = {https://dx.doi.org/10.1007/s00222-012-0416-1},
 }
 
 @ARTICLE{Spivakovsky,
@@ -5415,13 +5415,13 @@
       YEAR = {1999},
     NUMBER = {2},
      PAGES = {381--444},
-       URL = {http://dx.doi.org/10.1090/S0894-0347-99-00294-5},
+       URL = {https://dx.doi.org/10.1090/S0894-0347-99-00294-5},
 }
 
 @MISC{stacks-project,
 	AUTHOR	= {The {Stacks Project Authors}},
 	TITLE	= {Stacks Project},
-	URL = {http://stacks.math.columbia.edu/},
+	URL = {https://stacks.math.columbia.edu/},
 }
 
 @UNPUBLISHED{S1,
@@ -5553,7 +5553,7 @@
       YEAR = {2010},
     NUMBER = {4},
      PAGES = {603--677},
-       URL = {http://dx.doi.org/10.1090/S1056-3911-2010-00560-7},
+       URL = {https://dx.doi.org/10.1090/S1056-3911-2010-00560-7},
 }
 
 @MISC{Temkin-Tyomkin,
@@ -5655,7 +5655,7 @@
  PUBLISHER = {Cambridge University Press, Cambridge},
       YEAR = {2014},
      PAGES = {xvi+228},
-       URL = {http://dx.doi.org/10.1017/CBO9781139059480},
+       URL = {https://dx.doi.org/10.1017/CBO9781139059480},
 }
 
 @ARTICLE{Tsen,
@@ -5692,7 +5692,7 @@
 @MISC{FOAG,
 	AUTHOR	= {Vakil, Ravi},
 	TITLE	= {{MATH 216: Foundations of Algebraic Geometry}},
-	URL = {http://math.stanford.edu/~vakil/216blog/},
+	URL = {https://math.stanford.edu/~vakil/216blog/},
 }
 
 @ARTICLE{Ravi-Murphys-Law,
@@ -5704,7 +5704,7 @@
     NUMBER = {3},
      PAGES = {569--590},
       ISSN = {0020-9910},
-       URL = {http://dx.doi.org/10.1007/s00222-005-0481-9},
+       URL = {https://dx.doi.org/10.1007/s00222-005-0481-9},
 }
 
 @ARTICLE{vdB-rigid,
@@ -5715,7 +5715,7 @@
       YEAR = {1997},
     NUMBER = {2},
      PAGES = {662--679},
-       URL = {http://dx.doi.org/10.1006/jabr.1997.7052},
+       URL = {https://dx.doi.org/10.1006/jabr.1997.7052},
 }
 
 @ARTICLE{vanderPut,
@@ -5774,7 +5774,7 @@
       TITLE       = {Notes on {G}rothendieck topologies, fibered categories and descent theory},
       YEAR        = {2004},
       EPRINT      = {math/0412512},
-      URL         = {http://arxiv.org/abs/math/0412512},
+      URL         = {https://arxiv.org/abs/math/0412512},
 }
 
 @ARTICLE{vistoli_intersection,
@@ -5908,7 +5908,7 @@
       YEAR = {2009},
     NUMBER = {13},
      PAGES = {2417--2475},
-       URL = {http://dx.doi.org/10.1093/imrn/rnp021},
+       URL = {https://dx.doi.org/10.1093/imrn/rnp021},
 }
 
 @ARTICLE{Yekutieli,
@@ -5939,7 +5939,7 @@
       YEAR = {2009},
     NUMBER = {1},
      PAGES = {19--52},
-       URL = {http://dx.doi.org/10.1007/s10468-008-9102-9},
+       URL = {https://dx.doi.org/10.1007/s10468-008-9102-9},
 }
 
 @ARTICLE{Yoneda-homology,

--- a/my.bib
+++ b/my.bib
@@ -1010,7 +1010,7 @@
       TITLE       = {Die {B}rauersche {G}ruppe; ihre {V}erallgemeinerungen und {A}nwendungen in der {A}rithmetischen {G}eometrie},
       YEAR        = {2001},
       NOTE        = {preprint},
-      URL         = {https://www.math.u-psud.fr/~colliot/liste-prepub.html},
+      URL         = {https://www.math.u-psud.fr/~colliot/brauer.ps},
 }
 % it's not really a preprint I think
 
@@ -2984,9 +2984,9 @@
 @UNPUBLISHED{dJS3,
       AUTHOR      = {de Jong, Aise Johan and Starr, Jason},
       YEAR        = {2005},
-      TITLE       = {Divisor classes and the virtual canonical bundle},
+      TITLE       = {Divisor classes and the virtual canonical bundle for genus 0 maps},
       NOTE        = {preprint},
-      URL         = {http://www-math.mit.edu/~jstarr/papers/index.html},
+      URL         = {https://www.math.stonybrook.edu/~jstarr/papers/cc.pdf},
 }
 
 @ARTICLE{Jongmin,
@@ -4599,7 +4599,7 @@
     AUTHOR = {Olsson, Martin Christian},
   TITLE = {Course notes for {M}ath 274: {S}tacks, taken by {A}nton {G}eraschenko},
   YEAR = {2007},
-  URL = {https://math.berkeley.edu/~anton/written/Stacks/Stacks.pdf},
+  URL = {https://stacky.net/files/written/Stacks/Stacks.pdf},
 }
 
 @ARTICLE{olsson-starr,
@@ -5453,7 +5453,7 @@
       YEAR        = {2004},
       TITLE       = {Global sections of some vector bundles on {K}ontsevich moduli spaces},
       NOTE        = {preprint},
-      URL         = {http://www-math.mit.edu/~jstarr/papers/},
+      URL         = {https://www.math.stonybrook.edu/~jstarr/papers/globsecs.pdf},
 }
 % this one seems really unpublished, not in preparation
 

--- a/properties.tex
+++ b/properties.tex
@@ -3161,7 +3161,7 @@ module $\mathcal{F}$ is the union of its quasi-coherent
 $\kappa$-generated subsheaves. It follows that the category of quasi-coherent
 sheaves on a scheme is a Grothendieck abelian category having
 limits and enough injectives\footnote{Nicely explained in a
-\href{http://amathew.wordpress.com/2011/07/30/quasi-coherent-sheaves-presentable-categories-and-a-result-of-gabber/}{blog post}
+\href{https://amathew.wordpress.com/2011/07/30/quasi-coherent-sheaves-presentable-categories-and-a-result-of-gabber/}{blog post}
 by Akhil Mathew.}.
 
 \begin{definition}

--- a/scripts/tag_up.py
+++ b/scripts/tag_up.py
@@ -17,7 +17,7 @@ name = argv[2]
 
 def replace_newtheorem(line):
 	if line.find("\\newtheorem{") == 0:
-		line = line.replace("]{", "]{\\href{http://stacks.math.columbia.edu/tag/\\TAG}{",1)
+		line = line.replace("]{", "]{\\href{https://stacks.math.columbia.edu/tag/\\TAG}{",1)
 		line = line.rstrip()
 		return line + "}\n"
 	if line.find("\\documentclass") == 0:


### PR DESCRIPTION
In the process I repaired two or three links which fell prey to bitrot.

(This pull request wasn't created using blind search/replace. I used a [script](https://github.com/luga-ev/website/blob/master/rewrite-http-to-https.pl) to upgrade only those http urls for which the corresponding https url works.)