### PR TITLE
Explicitly invoke python2 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,10 @@ pdfs: $(FOOS) $(BARS) $(PDFS)
 
 # Automatically generated tex files
 tmp/index.tex: *.tex
-	python ./scripts/make_index.py "$(CURDIR)" > tmp/index.tex
+	python2 ./scripts/make_index.py "$(CURDIR)" > tmp/index.tex
 
 tmp/book.tex: *.tex tmp/index.tex
-	python ./scripts/make_book.py "$(CURDIR)" > tmp/book.tex
+	python2 ./scripts/make_book.py "$(CURDIR)" > tmp/book.tex
 
 # Creating aux files
 index.foo: tmp/index.tex
@@ -159,19 +159,19 @@ book.dvi: tmp/book.tex book.bar
 #
 #
 tags/tmp/book.tex: tmp/book.tex tags/tags
-	python ./scripts/tag_up.py "$(CURDIR)" book > tags/tmp/book.tex
+	python2 ./scripts/tag_up.py "$(CURDIR)" book > tags/tmp/book.tex
 
 tags/tmp/index.tex: tmp/index.tex
 	cp tmp/index.tex tags/tmp/index.tex
 
 tags/tmp/preamble.tex: preamble.tex tags/tags
-	python ./scripts/tag_up.py "$(CURDIR)" preamble > tags/tmp/preamble.tex
+	python2 ./scripts/tag_up.py "$(CURDIR)" preamble > tags/tmp/preamble.tex
 
 tags/tmp/chapters.tex: chapters.tex
 	cp chapters.tex tags/tmp/chapters.tex
 
 tags/tmp/%.tex: %.tex tags/tags
-	python ./scripts/tag_up.py "$(CURDIR)" $* > tags/tmp/$*.tex
+	python2 ./scripts/tag_up.py "$(CURDIR)" $* > tags/tmp/$*.tex
 
 tags/tmp/stacks-project.cls: stacks-project.cls
 	cp stacks-project.cls tags/tmp/stacks-project.cls


### PR DESCRIPTION
The current `Makefile` assumes `python` means `python2`. This is less and less realistic (and prevented me to follow instruction in http://pbelmans.ncag.info/blog/2018/01/05/introducing-gerby-tools/). 

Note that a different fix would be to rewrite the scripts to be compatible with both python 2 and python 3 (I can probably do that if you prefer).