### PR TITLE
Interchanged p and q in the proof of 00KV and 0BBZ

### DIFF
--- a/algebra.tex
+++ b/algebra.tex
@@ -24644,8 +24644,8 @@ for the maximal ideal $\mathfrak m$, see
 Definition \ref{definition-regular-local}.
 There is a surjection $\kappa[X_1, \ldots, X_d]
 \to \bigoplus \mathfrak m^n/\mathfrak m^{n + 1}$,
-which maps the class of $x_i$ in $\mathfrak m/\mathfrak m^2$
-to $X_i$. Since $d(R) = d$ by
+which maps $X_i$ to the class of $x_i$ in $\mathfrak m/\mathfrak m^2$.
+Since $d(R) = d$ by
 Proposition \ref{proposition-dimension}
 we know that the numerical
 polynomial $n \mapsto \dim_\kappa \mathfrak m^n/\mathfrak m^{n + 1}$

--- a/algebra.tex
+++ b/algebra.tex
@@ -14040,8 +14040,8 @@ $\mathfrak pR_\mathfrak p$ is the only prime ideal and we see
 that the height is $0$.
 
 \medskip\noindent
-Proof of (2). By part (1) we see that $\mathfrak p/\mathfrak q$
-is a prime of height $1$ or $0$ in $R/\mathfrak q$. This immediately
+Proof of (2). By part (1) we see that $\mathfrak q/\mathfrak p$
+is a prime of height $1$ or $0$ in $R/\mathfrak p$. This immediately
 implies there cannot be a prime strictly between $\mathfrak p$
 and $\mathfrak q$.
 \end{proof}
@@ -14069,7 +14069,7 @@ Hence Proposition \ref{proposition-dimension} shows
 $\dim(R_\mathfrak p) \leq r$.
 
 \medskip\noindent
-Proof of (2). By part (1) we see that $\mathfrak p/\mathfrak q$
+Proof of (2). By part (1) we see that $\mathfrak q/\mathfrak p$
 is a prime of height $\leq r$. This immediately
 implies the statement about chains of primes between $\mathfrak p$
 and $\mathfrak q$.


### PR DESCRIPTION
This should fix [comment #3527](https://stacks.math.columbia.edu/tag/00KV#comment-3527).