### PR TITLE
Minor fix in "less naive" stackification

### DIFF
--- a/stacks.tex
+++ b/stacks.tex
@@ -1586,17 +1586,17 @@ $(\text{Ob}, \text{Arrows}, s, t, \circ)$ as in
 Categories, Section \ref{categories-section-definition-categories}.
 Consider the forgetful functor
 $$
-forget : \textit{Cat} \to \textit{Sets}, \quad
+forget : \textit{Cat} \to \textit{Sets} \times \textit{Sets}, \quad
 (\text{Ob}, \text{Arrows}, s, t, \circ)
 \mapsto
-\text{Ob} \amalg \text{Arrows}.
+(\text{Ob}, \text{Arrows}).
 $$
 Then $forget$ is faithful, $\textit{Cat}$ has limits and
 $forget$ commutes with them, $\textit{Cat}$ has directed colimits and
 $forget$ commutes with them, and $forget$ reflects isomorphisms.
-Hence, according to the first part of
+We can sheafify presheaves with values in $\textit{Cat}$, and
+by an argument similar to the one in the first part of
 Sites, Section \ref{sites-section-sheaves-algebraic-structures}
-we can sheafify presheaves with values in $\textit{Cat}$, and
 the result commutes with $forget$. Applying this to
 $\mathcal{S}$ we obtain a sheafification $\mathcal{S}^\#$
 which has a sheaf of objects and a sheaf of morphisms


### PR DESCRIPTION
Here is the commit message which describes the issue and the proposed fix:

> The construction claims that the functor Cat -> Sets that maps
> a category to the disjoint union of its objects and arrows
> commutes with limits which is not correct: For two categories
> C and D, the objects resp. arrows of C x D are just the product
> of corresponding objects resp. arrows, but the product of
> disjoint unions of objects and arrows has "mixed terms" like
> Ob(C) x Arrows(D).
>
> I think that this issue can be fixed by replacing the forgetful
> functor by (Ob, Arrows) : Cat -> Sets x Sets: It is still
> faithful, reflects isomorphisms, actually commutes with limits
> (as it "is" the right adjoint of the left Kan extension of
> F: {o, a} -> Cat with F(o)=[0] and F(a)=[1] along the Yoneda
> embedding {o, a} -> Sets^{{o,a}^op} ~ Sets x Sets) and commutes
> with directed colimits (which can be checked by verifying the Segal
> condition for the componentwise colimit using the fact that
> directed colimits commute with pullbacks).
> 
> A minor issue is that Tag 00YR ("Sheaves of algebraic structures")
> cannot be used directly because the target of the forgetful functor
> is not Sets, but sheafification should still commute with this
> forgetful functor as (co)limits in Sets x Sets are computed
> componentwise.

I would be willing to elaborate more on this if it is needed.
