### PR TITLE
Change a notation

### DIFF
--- a/homology.tex
+++ b/homology.tex
@@ -895,7 +895,7 @@ Lemma \ref{lemma-cartesian-cocartesian}, uniqueness of $\delta$ is clear.
 Let $p=y\times_z\Ker(\gamma)$ and $q=\Coker(\alpha)\amalg_uv$. 
 Let $h:\Ker(\beta)\to y$, $i:\Ker(\gamma)\to z$ and 
 $j:\Ker(\pi)\rightarrow p$ be the canonical injections. 
-Let $p:u\to\Coker(\alpha)$ be the canonical projection. 
+Let $\pi'':u\to\Coker(\alpha)$ be the canonical projection. 
 Keeping in mind Lemma \ref{lemma-cartesian-cocartesian} we get a commutative 
 diagram with exact rows 
 $$
@@ -906,7 +906,7 @@ p \ar[r]^{\pi} \ar[d]_{\pi'} &
 \Ker(\gamma) \ar[d]_i \ar[r] & 0 \\
 & x \ar[r]^f \ar[d]_\alpha & y \ar[r]^g \ar[d]_\beta &
 z \ar[d]_\gamma \ar[r] & 0 \\
-0 \ar[r] & u \ar[r]^k \ar[d]_p &
+0 \ar[r] & u \ar[r]^k \ar[d]_{\pi''} &
 v \ar[r]^l \ar[d]_{\iota'} & w & \\
 0 \ar[r] & \Coker(\alpha) \ar[r]^\iota & q & &
 }
@@ -920,12 +920,12 @@ It follows
 $k \circ a \circ j \circ b = \beta \circ \pi' \circ j \circ b =
 \beta \circ f = k \circ \alpha$.
 As $k$ is a monomorphism this implies $a \circ j \circ b = \alpha$. It follows 
-$p \circ a \circ j \circ b = p \circ \alpha = 0$. As $b$ is an epimorphism this 
-implies $p\circ a\circ j=0$. Therefore, as the top row of the diagram 
+$\pi'' \circ a \circ j \circ b = \pi'' \circ \alpha = 0$. As $b$ is an epimorphism this 
+implies $\pi''\circ a\circ j=0$. Therefore, as the top row of the diagram 
 above is exact, there exists
 $\delta : \Ker(\gamma) \to \Coker(\alpha)$ with
-$\delta \circ \pi = p \circ a$. It follows 
-$\iota \circ \delta \circ \pi = \iota \circ p \circ a =
+$\delta \circ \pi = \pi'' \circ a$. It follows 
+$\iota \circ \delta \circ \pi = \iota \circ \pi'' \circ a =
 \iota' \circ k \circ a = \iota' \circ \beta \circ \pi'$
 as desired.
 
@@ -942,7 +942,7 @@ Next, let $d : r \to \Ker(\gamma)$ with $\delta \circ d = 0$. Applying
 Lemma \ref{lemma-check-exactness-fibre-product} to the exact sequence 
 $p \overset{\pi}\to \Ker(\gamma) \to 0$ and $d$ yields an object $s$, 
 an epimorphism $m : s \to r$ and a morphism $n : s \to p$ with 
-$\pi \circ n = d \circ m$. As $p \circ a \circ n = \delta \circ d \circ m = 0$, 
+$\pi \circ n = d \circ m$. As $\pi'' \circ a \circ n = \delta \circ d \circ m = 0$, 
 applying Lemma \ref{lemma-check-exactness-fibre-product} to the exact sequence 
 $x \overset{\alpha}\to u \overset{p}\to \Coker(\alpha)$ and 
 $a \circ n$ yields an object $t$, an epimorphism $\varepsilon : t \to s$ and 


### PR DESCRIPTION
The p’s denoting the morphism from u to Coker(α) have been replaced by π’’ because p also denotes the fibre product of y and Ker(γ).