### PR TITLE
Fix a small typo in categories.tex

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -1052,7 +1052,7 @@ a unique morphism $s : W \to Z$ such that $t = e \circ s$.
 \end{definition}
 
 \noindent
-As in the case of the fibre product above, equalizers when
+As in the case of the fibre products above, equalizers when
 they exist are unique up to unique isomorphism. There is a
 straightforward generalization of this definition to the
 case where we have more than $2$ morphisms.


### PR DESCRIPTION
The word ‘product’ was made plural (as ‘pushouts’ in the following section).