### PR TITLE
Fix notation and typo

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -1553,7 +1553,7 @@ exists and is the same.
 \end{lemma}
 
 \begin{proof}
-Let $M \to X$ be an object representing the limit in $\mathcal{C}/X$.
+Let $L \to X$ be an object representing the limit in $\mathcal{C}/X$.
 Consider the functor
 $$
 W \longmapsto \lim_i \Mor_\mathcal{C}(W, M_i).
@@ -1564,10 +1564,10 @@ get morphisms $f_i = s_i \circ \varphi_i : W \to X$. But as $\mathcal{I}$
 is connected we see that all $f_i$ are equal. Since $\mathcal{I}$
 is nonempty there is at least one $f_i$.
 Hence this common value $W \to X$ defines the structure of an
-object of $W$ in $\mathcal{C}/X$ and $(\varphi_i)$ defines is an
+object of $W$ in $\mathcal{C}/X$ and $(\varphi_i)$ defines an
 element of $\lim_i \Mor_{\mathcal{C}/X}(W, M_i)$.
-Thus we obtain a unique morphism $\phi : W \to M$ such that
-$\varphi_i$ is the composition of $\phi$ with $M \to M_i$ as desired.
+Thus we obtain a unique morphism $\phi : W \to L$ such that
+$\varphi_i$ is the composition of $\phi$ with $L \to M_i$ as desired.
 \end{proof}
 
 \begin{lemma}


### PR DESCRIPTION
The symbol M denotes both a diagram (in the statement) and a limit (in proof).
I have changed the latter.