### PR TITLE
pr_i —> \text{pr}_i

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -3172,7 +3172,7 @@ Suppose (3) holds. The fibre product over the final object is the product.
 If $a, b : A \to B$ are morphisms of $\mathcal{A}$, then the
 equalizer of $a, b$ is
 $$
-(A \times_{a, B, b} A)\times_{(pr_1, pr_2), A \times A, \Delta} A.
+(A \times_{a, B, b} A)\times_{(\text{pr}_1, \text{pr}_2), A \times A, \Delta} A.
 $$
 Thus (3) implies (2). Finally (1) implies (3) because
 the empty limit is a final object, and fibre products are limits.

--- a/categories.tex
+++ b/categories.tex
@@ -1907,7 +1907,7 @@ we see that finite nonempty limits exist, i.e., (1) holds. Assume (3).
 If $a, b : A \to B$ are morphisms of $\mathcal{C}$, then the
 equalizer of $a, b$ is
 $$
-(A \times_{a, B, b} A)\times_{(pr_1, pr_2), A \times A, \Delta} A.
+(A \times_{a, B, b} A)\times_{(\text{pr}_1, \text{pr}_2), A \times A, \Delta} A.
 $$
 Thus (3) implies (2), and the lemma is proved.
 \end{proof}
@@ -1933,7 +1933,7 @@ Note that the product $A \times B$ is the fibre product over the
 final object. If $a, b : A \to B$ are morphisms of $\mathcal{C}$, then the
 equalizer of $a, b$ is
 $$
-(A \times_{a, B, b} A)\times_{(pr_1, pr_2), A \times A, \Delta} A.
+(A \times_{a, B, b} A)\times_{(\text{pr}_1, \text{pr}_2), A \times A, \Delta} A.
 $$
 Thus (3) implies (2) and the lemma is proved.
 \end{proof}


### PR DESCRIPTION
According to, e.g., the line 1880 of this file.