### PR TITLE
Fix a notation in sheaves (small changes)

### DIFF
--- a/sheaves.tex
+++ b/sheaves.tex
@@ -2251,10 +2251,10 @@ functorially in $\mathcal{F} \in \Sh(X)$ and $\mathcal{G} \in \Sh(Y)$.
 \end{lemma}
 
 \begin{proof}
-A map of sheaves $a : \mathcal{G} \to f_\star\mathcal{F}$
+A map of sheaves $a : \mathcal{G} \to f_*\mathcal{F}$
 is by definition a rule which to each open $V$ of $Y$ assigns
-a map $a_V : \mathcal{G}(V) \to f_\star\mathcal{F}(V)$
-and we have $f_\star\mathcal{F}(V) = \mathcal{F}(f^{-1}(V))$.
+a map $a_V : \mathcal{G}(V) \to f_*\mathcal{F}(V)$
+and we have $f_*\mathcal{F}(V) = \mathcal{F}(f^{-1}(V))$.
 Thus at least the "data" corresponds exactly to what you need
 for an $f$-map $\xi$ from $\mathcal{G}$ to $\mathcal{F}$.
 To show that (1) and (2) are in bijection is that the fact that


### PR DESCRIPTION
For consistency.
The pushforward functor for sheaves is denoted by f_* in other places, not f_{\star}.