### PR TITLE
Fix an element of an ideal

### DIFF
--- a/divisors.tex
+++ b/divisors.tex
@@ -7635,7 +7635,7 @@ $\mathcal{I} \subset \mathcal{A}$ the kernel of the canonical map
 $$
 \mathcal{A}
 \longrightarrow
-\bigoplus\nolimits_{d \geq 0} p_*\left((i_*\mathcal{O}_Z)(d)\right)
+\bigoplus\nolimits_{d \geq 0} p_*\left((i_*\mathcal{O}_Z)(d)\right).
 $$
 If $p$ is quasi-compact, then there is an isomorphism
 $Z = \underline{\text{Proj}}_S(\mathcal{A}/\mathcal{I})$.
@@ -7693,7 +7693,7 @@ Conversely, suppose that $g/f_0^e \in J$. Again we may assume $d | e$.
 Pick $i \in \{1, \ldots, n\}$. Then $Z \cap D_{+}(f_i)$ is
 cut out by some ideal $J_i \subset A_{(f_i)}$. Moreover,
 $$
-J \cdot A_{(f_0f_i)} = J_i \cdot A_{(f_0f_i)}
+J \cdot A_{(f_0f_i)} = J_i \cdot A_{(f_0f_i)}.
 $$
 The right hand side is the localization of $J_i$ with respect to
 $f_0^{\deg(f_i)}/f_i^{\deg(f_0)}$. It follows that
@@ -7703,7 +7703,7 @@ $$
 for some $e_i \gg 0$ sufficiently divisible. This proves that
 $f_0^{\max(e_i)}g$ is an element of $I$, because its restriction to each
 affine open $D_{+}(f_i)$ vanishes on the closed subscheme
-$Z \cap D_{+}(f_i)$. Hence $g \in J'$ and we conclude $J \subset J'$
+$Z \cap D_{+}(f_i)$. Hence $g/f_0^e \in J'$ and we conclude $J \subset J'$
 as desired.
 \end{proof}
 


### PR DESCRIPTION
Since the ideal J' is an ideal of the ring A_(f_0), its element should be of degree 0, i.e. the element g should be g/f_0^e.