### PR TITLE
Fix small typos

### DIFF
--- a/algebra.tex
+++ b/algebra.tex
@@ -16357,7 +16357,7 @@ for each $i = 1, \ldots, r$, and
 \item the module $M/(f_1, \ldots, f_r)M$ is not zero.
 \end{enumerate}
 If $I$ is an ideal of $R$ and $f_1, \ldots, f_r \in I$
-then we call $f_1, \ldots, f_r$ a {\it $M$-regular sequence
+then we call $f_1, \ldots, f_r$ an {\it $M$-regular sequence
 in $I$}. If $M = R$, we call $f_1, \ldots, f_r$ simply a
 {\it regular sequence} (in $I$).
 \end{definition}

--- a/categories.tex
+++ b/categories.tex
@@ -2073,7 +2073,7 @@ We give a counter example to the lemma in
 the case where $\mathcal{J}$ is infinite. Namely, let
 $\mathcal{I}$ consist of $\mathbf{N} = \{1, 2, 3, \ldots\}$
 with a unique morphism $i \to i'$ whenever $i \leq i'$.
-Let $\mathcal{J}$ consist of the discrete category
+Let $\mathcal{J}$ be the discrete category
 $\mathbf{N} = \{1, 2, 3, \ldots\}$ (only morphisms are identities).
 Let $M_{i, j} = \{1, 2, \ldots, i\}$ with obvious inclusion maps
 $M_{i, j} \to M_{i', j}$ when $i \leq i'$. In this case
@@ -2131,8 +2131,8 @@ do not commute with finite nonempty products.
 Proof of (1). Let $(\overline{m}, \overline{n})$
 be an element of $\colim M_i \times \colim N_i$.
 Then we can find $m \in M_x$ and $n \in N_y$ for some
-$x, y \in \Ob(\mathcal{I})$ such that $m$ mapsto
-$\overline{m}$ and $n$ mapsto $\overline{n}$. See
+$x, y \in \Ob(\mathcal{I})$ such that $m$ maps to
+$\overline{m}$ and $n$ maps to $\overline{n}$. See
 Section \ref{section-limit-sets}.
 Choose $a : x \to z$ and $b : y \to z$
 in $\mathcal{I}$. Then $(M(a)(m), N(b)(n))$ is an element of
@@ -2690,7 +2690,7 @@ object of $\mathcal{I}$ is the final object in the subcategory
 consisting of only that object and its identity arrow, the functor
 $M_0$ is surjective on objects. In particular, Condition (1) of
 Definition \ref{definition-cofinal} is satisfied. Given
-an object $i$ of $\mathcal{I}$, $\mathcal{F}_1, \mathcal{F}_2$ in
+an object $i$ of $\mathcal{I}$, objects $\mathcal{F}_1, \mathcal{F}_2$ in
 $\mathcal{I}_0$ and maps $\varphi_1 : i \to M_0(\mathcal{F}_1)$
 and $\varphi_2 : i \to M_0(\mathcal{F}_2)$ in
 $\mathcal{I}$, we can take $\mathcal{F}_{12}$ to be a finitely

--- a/sites.tex
+++ b/sites.tex
@@ -10018,7 +10018,7 @@ Details left to the reader.
 
 \medskip\noindent
 This method also works for sheaves of rings by thinking
-of a sheaf of rings (with unit) as a sixtuple
+of a sheaf of rings (with unit) as a sextuple
 $(\mathcal{O}, + , 0, i, \cdot, 1)$ satisfying a list
 of axioms that you can find in any elementary
 algebra book.


### PR DESCRIPTION
I fixed some small typos.
Moreover, "mapsto" --> "maps to" for consistency, and insert "objects" to avoid confusion.