### PR TITLE
fix(homology.tex): abelian categories should be nonempty

### DIFF
--- a/homology.tex
+++ b/homology.tex
@@ -464,7 +464,7 @@ Example \ref{example-not-abelian} shows that it is necessary.
 \begin{definition}
 \label{definition-abelian-category}
 A category $\mathcal{A}$ is {\it abelian} if
-it is additive, if all kernels and cokernels exist,
+it is nonempty, additive, if all kernels and cokernels exist,
 and if the natural map $\Coim(f) \to \Im(f)$
 is an isomorphism for all morphisms $f$ of
 $\mathcal{A}$.


### PR DESCRIPTION
Abelian categories should have a zero object, but the current definition allows the empty category to be abelian.