### PR TITLE
Added more details and implicit results to the theory of preadditive and abelian categories

### DIFF
--- a/categories.tex
+++ b/categories.tex
@@ -1647,6 +1647,7 @@ $$
 commute for $k = 0, \ldots, n - 1$.
 \end{enumerate}
 \end{definition}
+Note that in condition (2) the direction imposed on the first and last morphism does not actually suppose a restriction, for we can always extend a zig-zag of morphisms by identities on the ends.
 
 \begin{lemma}
 \label{lemma-cofinal}

--- a/categories.tex
+++ b/categories.tex
@@ -1111,13 +1111,14 @@ is a final object (so it is not unique).
 Let $\mathcal{C}$ be a category and let $f : X \to Y$ be
 a morphism of $\mathcal{C}$.
 \begin{enumerate}
-\item We say that $f$ is a {\it monomorphism} if for every object
+\item We say that $f$ is a {\it monomorphism} or a {\it mono} if for every object
 $W$ and every pair of morphisms $a, b : W \to X$ such that
 $f \circ a = f \circ b$ we have $a = b$.
-\item We say that $f$ is an {\it epimorphism} if for every object
+\item We say that $f$ is an {\it epimorphism} or an {\it epi} if for every object
 $W$ and every pair of morphisms $a, b : Y \to W$ such that
 $a \circ f = b \circ f$ we have $a = b$.
 \end{enumerate}
+In adjectival form, in the cases (1) and (2) we also say that $f$ is {\it monic} or {\it epic}, respectively.
 \end{definition}
 
 \begin{example}
@@ -1142,9 +1143,32 @@ $Y \amalg_X Y$.
 Omitted.
 \end{proof}
 
+\begin{lemma}\label{lemma-new-mono-epi-from-old}
+	Let $\mathcal{C}$ be a category. If $f:x\to y$ and $g:y\to z$ are morphisms of $\mathcal{C}$ so that $gf$ is monic, then $f$ is monic. Dually, if $gf$ is epic, then $g$ is epic.
+\end{lemma}
+\begin{proof}
+	Ommited.
+\end{proof}
 
+Note that in any category every isomorphism is both a monomorphism and a epimorphism. However, the converse does not hold in general (the inclusion $\mathbb{Z}\hookrightarrow\mathbb{Q}$ in the category of commutative rings is epic and monic but it is not an isomorphism). Nonetheless, an additional condition can be imposed on the mono or the epi for the converse to hold.
 
-
+\begin{definition}\label{definition-regular-mono-epi}
+	Let $\mathcal{C}$ be a category and let $f:X\to Y$ be a morphism of $\mathcal{C}$. We say that $f$ is a {\it regular monomorphism} if it is an equalizer. That is, if there exist $a,b:Y\to Z$ in $\mathcal{C}$ such that $f$ is the equalizer of the pair $(a,b)$.
+	
+	Dually, we say that $f$ is a {\it regular epimorphism} if it is a coequalizer, i.e., if there are $c,d:W\to X$ in $\mathcal{C}$ such that $f$ is the coequalizer of $(c,d)$.
+\end{definition}
+From the definition of a (co)equalizer, it is not difficult to show that any regular monomorphism (epimorphism) is indeed monic (epic).
+\begin{lemma}\label{lemma-characterize-iso}
+	Let $\mathcal{C}$ be a category and let $f:X\to Y$ be a morphism of $\mathcal{C}$. The following are equivalent:
+	\begin{enumerate}
+		\item $f$ is an isomorphism,
+		\item $f$ is an epimorphism and a regular monomorphism, and
+		\item $f$ is a monomorphism and a regular epimorphism.
+	\end{enumerate}
+\end{lemma}
+\begin{proof}
+	Ommited.
+\end{proof}
 
 \section{Limits and colimits}
 \label{section-limits}

--- a/homology.tex
+++ b/homology.tex
@@ -243,6 +243,22 @@ because the kernel of $f : x \to y$ represents the functor
 sending an object $z$ to the set
 $\Ker(\Mor_\mathcal{A}(z, x) \to \Mor_\mathcal{A}(z, y))$. Dually, the cokernel of $f:x\to y$ represents the functor sending an object $w$ to the set $\Ker(\Mor_\mathcal{A}(y,w) \to \Mor_\mathcal{A}(x,w))$.
 
+If the preadditive category $\mathcal{A}$ has a zero object, then $i:z\to x$ is a kernel of $f:x\to y$ if and only if the square
+$$
+\xymatrix{
+	z\ar[r]^i\ar[d] &x\ar[d]^f\\
+	0\ar[r]&y
+}
+$$
+is cartesian. And $p:y\to z$ is a cokernel of $f:x\to y$ if and only if the square
+$$
+\xymatrix{
+	x\ar[r]^f\ar[d] &y\ar[d]^p\\
+	0\ar[r]&z
+}
+$$
+is cocartesian.
+
 \medskip\noindent
 We first relate the direct sum to kernels as follows.
 

--- a/homology.tex
+++ b/homology.tex
@@ -620,7 +620,7 @@ $$
 $$
 commutes, $f$ and $\Im f\to y$ are isomorphic as objects over $y$. Thus $f$ is its own image.
 
-(7)$\Rightarrow$(6) By uniqueness of the image factorization, the canonical morphism $x\to\Im f=x$ must be the identity.f
+(7)$\Rightarrow$(6) By uniqueness of the image factorization, the canonical morphism $x\to\Im f=x$ must be the identity.
 
 The proof of the other equivalences is dual.
 \end{proof}
@@ -761,6 +761,14 @@ $x \times_y z = \Ker((a, -b) : x \oplus z \to y)$.
 we have the pushout:
 $x \amalg_y z = \Coker((a, -b) : y \to x \oplus z)$.
 \end{enumerate}
+We can also compute the (co)kernel of the composition in terms of a (co)cartesian diagram: If $x\xrightarrow{f}y\xrightarrow{g}z$ are morphisms in $\mathcal{A}$, then
+\begin{align*}
+	\Ker(gf)&=x\times_y\Ker g\\
+	\Coker(gf)&=z\amalg_y\Coker f.
+\end{align*}
+Using the universal properties of $\Ker g$ and of $x\times_y\Ker g$, it is not difficult to show that $x\times_y\Ker g$ is indeed a kernel of $gf$. By a duality argument, it follows that $\Coker(gf)=z\amalg_y\Coker f$.
+
+In particular, since a (co)kernel can be defined in terms of a (co)cartesian diagram (see comments before Lemma \ref{lemma-additive-cat-biproduct-kernel}), it follows that if $g$ is injective if and only if $\Ker(gf)=\Ker f$ for every morphism $f$ pre-composable with $g$. Dually, we have that $f$ is surjective if and only if $\Coker(gf)=\Coker g$ for every morphism $g$ post-composable with $f$.
 \end{example}
 
 \begin{definition}
@@ -827,8 +835,10 @@ and so, it follows that $gf=0$ since the composite $\Ker g\to y\xrightarrow{g}z$
 		\item[(iii)] By a duality argument and since exactness is a self-dual property (Lemma \ref{lemma-exact-self-dual}), from (ii) it follows that a morphism $g:y\to z$ will be a cokernel of the morphism $f:x\to y$ if and only if the sequence $x\xrightarrow{f}y\xrightarrow{g}z\to 0$ is exact.
 	\end{enumerate}
 \end{remark}
+\noindent
+In an abelian category, using the previous facts, we can also characterize short exact sequences in the following way: a sequence $0\to A\xrightarrow{f} B\xrightarrow{g} C\to 0$ is short exact if and only if $f=\Ker g$ and $g=\Coker f$ and if and only if $f$ is injective, $g$ is surjective and $y/x=z$.
 
-\begin{lemma}
+\begin{lemma}\label{lemma-complex-im-subob-ker}
 	\begin{slogan}
 		In a complex from an abelian category, the image of a morphism is a subobject of the kernel of the next morphism.
 	\end{slogan}
@@ -839,7 +849,7 @@ and so, it follows that $gf=0$ since the composite $\Ker g\to y\xrightarrow{g}z$
 	\Im f\ar[r]^{i'}&\Ker g\ar[u]	
 	}
 	$$
-	is commutative, where $x\to\Im f$ is the canonical morphism. Moreover, such a morphism $i'$ is unique and monic, and we have that $x\xrightarrow{f}y\xrightarrow{g}z$ is exact if and only if $i'$ is an isomorphism.
+	is commutative, where $x\to\Im f$ is the canonical morphism. Moreover, such a morphism $i'$ is unique and injective, and we have that $x\xrightarrow{f}y\xrightarrow{g}z$ is exact if and only if $i'$ is an isomorphism.
 \end{lemma}
 
 \begin{proof}
@@ -854,7 +864,7 @@ and so, it follows that $gf=0$ since the composite $\Ker g\to y\xrightarrow{g}z$
 	$$
 	Then we have $0=gf=gif'$. Since $f'$ is epic (Lemma \ref{lemma-all-epis-normal-coim-map-monic}), we deduce $0=gi$. Therefore $i$ factors as $i=ji'$. Since $i$ is monic (it is a normal monomorphism), by Lemma \ref{lemma-new-mono-epi-from-old} we deduce that $i'$ is also monic.
 	
-	Uniqueness of $i'$ follows from the fact that $f'$ is epic and $j$ is monic, and we've proven that $i'$ must be a monomorphism.
+	Uniqueness of $i'$ follows from the fact that $f'$ is epic and $j$ is monic, and we've proven that $i'$ must be a monomorphism, and thus injective.
 	
 	On the other hand, if $x\xrightarrow{f}y\xrightarrow{g}z$ is exact, $\Im f=\Ker g$, then $i'$ must be the identity. And if $i'$ is an isomorphism, then by the factorization $i=ji'$, we have that $\Im f$ and $\Ker g$ are isomorphic as objects over $y$, so $\Im f=\Ker g$.
 \end{proof}
@@ -866,7 +876,7 @@ and so, it follows that $gf=0$ since the composite $\Ker g\to y\xrightarrow{g}z$
 	&\Coker f\ar[r]&\Coim g\ar[u]
 	}
 	$$
-	where $\Coker f\to\Coim g$ is epic.
+	where $\Coker f\to\Coim g$ is surjective.
 \end{remark}
 
 \noindent
@@ -1696,91 +1706,160 @@ Let $\mathcal{A}$ and $\mathcal{B}$ be abelian categories.
 Let $F : \mathcal{A} \to \mathcal{B}$ be a functor.
 \begin{enumerate}
 \item If $F$ is either left or right exact, then it is additive.
-\item $F$ is left exact if and only if
-for every short exact sequence
-$0 \to A \to B \to C \to 0$
-the sequence $0 \to F(A) \to F(B) \to F(C)$
-is exact.
-\item $F$ is right exact if and only if for every short exact sequence
-$0 \to A \to B \to C \to 0$
-the sequence $F(A) \to F(B) \to F(C) \to 0$
-is exact.
-\item $F$ is exact if and only if for every short exact sequence
-$0 \to A \to B \to C \to 0$
-the sequence $0 \to F(A) \to F(B) \to F(C) \to 0$
-is exact.
+\item The following are equivalent:
+\begin{enumerate}
+	\item[(i)] $F$ is left exact.
+	\item[(ii)] $F$ preserves kernels: For every exact sequence
+	$0 \to A \to B \to C$
+	the sequence $0 \to F(A) \to F(B) \to F(C)$
+	is exact.
+	\item[(iii)] For every short exact sequence
+	$0 \to A \to B \to C \to 0$
+	the sequence $0 \to F(A) \to F(B) \to F(C)$
+	is exact.
+\end{enumerate}
+\item[(2')] Dually, the following are equivalent:
+\begin{enumerate}
+	\item[(i')] $F$ is right exact.
+	\item[(ii')] $F$ preserves cokernels: For every exact sequence
+	$A \to B \to C\to 0$
+	the sequence $F(A) \to F(B) \to F(C)\to 0$
+	is exact.
+	\item[(iii')] For every short exact sequence
+	$0 \to A \to B \to C \to 0$
+	the sequence $F(A) \to F(B) \to F(C)\to 0$
+	is exact.
+\end{enumerate}
+%\item $F$ is right exact if and only if for every short exact sequence
+%$0 \to A \to B \to C \to 0$
+%the sequence $F(A) \to F(B) \to F(C) \to 0$
+%is exact.
+\item[(3)] The following are equivalent:
+\begin{enumerate}
+	\item[(\textsc{i})] $F$ is exact.
+	\item[(\textsc{ii})] $F$ preserves exact sequences:
+	for every exact sequence $A\to B\to C$
+	the sequence $F(A)\to F(B)\to F(C)$
+	is exact.
+	\item[(\textsc{iii})] $F$ preserves short exact sequences:
+	for every short exact sequence
+	$0 \to A \to B \to C \to 0$
+	the sequence $0 \to F(A) \to F(B) \to F(C) \to 0$
+	is exact.
+\end{enumerate}
 \end{enumerate}
 \end{lemma}
 
 \begin{proof}
-$F$ being left (right) exact means $F$ commutes with finite (co)limits, and in particular, $F$ commutes with finite (co)products. Thus, on either case $F$ is additive by Lemma \ref{lemma-additive-functor}.
-On the other hand, suppose that for every short exact sequence
-$0 \to A \to B \to C \to 0$ the sequence $0 \to F(A) \to F(B) \to F(C)$
-is exact. Let $A, B$ be two objects. Then we have a short
+(1). $F$ being left (right) exact means $F$ commutes with finite (co)limits
+and in particular, $F$ commutes with finite (co)products.
+Thus, on either case $F$ is additive by Lemma \ref{lemma-additive-functor}.
+
+\medskip\noindent
+(2). We are going to show that for the proof we can assume that $F$ is additive.
+By (1), condition (i) implies additivity.
+Hence, since (ii)$\Rightarrow$(iii) trivially,
+we have only to show that any functor $F$ that satisfies (iii) must be additive.
+Suppose then that $F$ is such a functor.
+On that case, $F$ will preserve the zero object,
+for it sends the trivial short exact sequence to the exact sequence $0\to F0 \xrightarrow{1_{F0}} F0 \xrightarrow{1_{F0}} F0$,
+so $0=\Ker 1_{F0}=\Im 1_{F0}=F0$.
+Let $A, B$ be two objects. Then we have a short
 exact sequence
 $$
 0 \to A \to A \oplus B \to B \to 0
 $$
 see for example Lemma \ref{lemma-additive-cat-biproduct-kernel}.
-By assumption, the lower row in the commutative diagram
+We want to apply the five lemma (Lemma \ref{lemma-five-lemma}) to the diagram
 $$
 \xymatrix{
 0 \ar[r] &
 F(A) \ar[d] \ar[r] &
-F(A) \oplus F(B) \ar[r] \ar[d] &
+F(A) \oplus F(B) \ar[r] \ar[d]^{Fi\amalg Fj} &
 F(B) \ar[d] \ar[r] &
 0 \\
 0 \ar[r] &
 F(A) \ar[r] &
-F(A \oplus B) \ar[r] &
-F(B)
+F(A \oplus B) \ar[r]_{Fq} &
+F(B)\ar[r]&0
 }
 $$
-is exact. Hence by the snake lemma (Lemma \ref{lemma-snake})
-we conclude that $F(A) \oplus F(B) \to F(A \oplus B)$ is an
-isomorphism. Hence $F$ is additive in this case as well.
-Thus for the rest of the proof we may assume $F$ is additive.
+to conclude that $Fi\amalg Fj$ is an
+isomorphism, so we verify the hypotheses.
+We know the top row of the diagram is exact, but also is the bottom row:
+On the one hand, by the assumption we deduce exactness of the bottom row at its first two non-zero terms.
+On the other hand, the bottom row is exact at $F(B)$ too,
+since $q:A\oplus B\to B$ has a retraction $j:B\to A\oplus B$,
+and functors preserve split epimorphisms (see also Remark \ref{remark-characterize-injective-exact-sequence}).
+Moreover, the diagram is commutative on the left square.
+To see that the right square also commutes,
+$Fq\circ(Fi\amalg Fj)=Fqi\amalg Fqj=F0\amalg F1_B=0\amalg 1_{FB}$
+(where $F$ preserves the zero map for we know it preserves the zero object).
+Hence $Fi\amalg Fj$ is an isomorphism and,
+by Lemma \ref{lemma-additive-functor}, $F$ is additive.
+Thus, for the rest of the proof we may assume $F$ is additive.
 
 \medskip\noindent
+(i)$\Rightarrow$(ii).
 Denote $f : B \to C$ a map from $B$ to $C$.
 Exactness of $0 \to A \to B \to C$ just means that
-$A = \Ker(f)$. Clearly the kernel of $f$ is
+$A = \Ker(f)$
+(see Remark \ref{remark-characterize-injective-exact-sequence}, (ii)).
+By definition, the kernel of $f$ is
 the equalizer of the two maps $f$ and $0$ from $B$ to $C$.
-Hence if $F$ commutes with limits, then $F(\Ker(f))
-= \Ker(F(f))$ which exactly means that
+Hence if $F$ commutes with finite limits, then $F(\Ker(f))
+= \Ker(F(f))$, which exactly means that
 $0 \to F(A) \to F(B) \to F(C)$ is exact.
 
 \medskip\noindent
-Conversely, suppose that $F$ is additive and
-transforms any short exact sequence $0 \to A \to B \to C \to 0$ into
-an exact sequence $0 \to F(A) \to F(B) \to F(C)$.
-Because it is additive it commutes with direct sums
-and hence finite products in $\mathcal{A}$. To show
-it commutes with finite limits it therefore
+(ii)$\Rightarrow$(iii). Trivial.
+
+\medskip\noindent
+(iii)$\Rightarrow$(i).
+Since $F$ is additive, it commutes with direct sums,
+and, hence, with finite products in $\mathcal{A}$. Therefore, to show
+it commutes with finite limits, it
 suffices to show that it commutes with
 equalizers. But equalizers in an abelian category
 are the same as the kernel of the difference map,
 hence it suffices to show that $F$ commutes with
 taking kernels. Let $f : A \to B$ be a morphism.
 Factor $f$ as $A \to I \to B$ with $f' : A \to I$ surjective
-and $i : I \to B$ injective. (This is possible by the
-definition of an abelian category.) Then it is
-clear that $\Ker(f) = \Ker(f')$. Also
+and $i : I \to B$ injective.
+(This is possible by the
+definition of an abelian category.)
+We have $\Ker(f) = \Ker(f')$
+(see last paragraph of Example \ref{example-fibre-product-pushouts}). Also
 $0 \to \Ker(f') \to A \to I \to 0$
 and
 $0 \to I \to B \to B/I \to 0$
-are short exact. By the condition imposed on $F$
+are short exact
+(See comments before Lemma \ref{lemma-complex-im-subob-ker}.
+The former sequence is exact by Lemma \ref{lemma-characterize-injective}, (1')$\Leftrightarrow$(7')).
+By the condition imposed on $F$
 we see that
 $0 \to F(\Ker(f')) \to F(A) \to F(I)$
 and
 $0 \to F(I) \to F(B) \to F(B/I)$
-are exact. Hence it is also the case that
-$F(\Ker(f'))$ is the kernel of the map
-$F(A) \to F(B)$, and we win.
+are exact. Hence $F(\Ker(f')) \to F(A)$ is a kernel of
+$F(A) \to F(I)$.
+Since pre-composing with injective morphisms does not change the kernel,
+$F(\Ker (f))=F(\Ker(f')) \to F(A)$
+is also a kernel of $F(f)$, and we win.
 
 \medskip\noindent
-The proof of (3) is similar to the proof of (2).
-Statement (4) is a combination of (2) and (3).
+(2') follows by a duality argument applied to (2).
+
+\medskip\noindent
+(3).
+
+\medskip\noindent
+(\textsc{i})$\Rightarrow$(\textsc{ii}). $F$ preserves finite (co)limits, so it preserves images and kernels.
+
+\noindent
+(\textsc{ii})$\Rightarrow$(\textsc{iii}). Obvious.
+
+\noindent(\textsc{iii})$\Rightarrow$(\textsc{i}). Follows from (2) and (2').
 \end{proof}
 
 \begin{lemma}

--- a/homology.tex
+++ b/homology.tex
@@ -497,6 +497,9 @@ $\mathcal{A}$.
 
 \begin{lemma}
 \label{lemma-abelian-opposite}
+\begin{slogan}
+	(Pre)abelianity is a self-dual property.
+\end{slogan}
 Let $\mathcal{A}$ be a preadditive category.
 The additions on sets of morphisms make
 $\mathcal{A}^{opp}$ into a preadditive category.
@@ -504,9 +507,6 @@ Furthermore, $\mathcal{A}$ is additive if and only if $\mathcal{A}^{opp}$
 is additive, and
 $\mathcal{A}$ is (pre)abelian if and only if $\mathcal{A}^{opp}$ is (pre)abelian.
 \end{lemma}
-\begin{slogan}
-	(Pre)abelianity is a self-dual property.
-\end{slogan}
 
 \begin{proof}
 The first statement is straightforward.
@@ -534,6 +534,16 @@ of $y$ and we use the notation $x \subset y$. If $x \to y$ is
 surjective, then we say that $y$ is a {\it quotient} of $x$.
 \end{definition}
 
+\noindent A morphism $f:x\to y$ in a preabelian category factors canonically through $\Im f$ and through $\Coim f$. This is because the composites $x\xrightarrow{f}y\to\Coker f$ and $\Ker f\to x\xrightarrow{f} y$ are always zero.
+$$
+\xymatrix{
+	x\ar[rr]^f\ar@{-->}[dr]_{\exists!}&&y&&
+	x\ar[rr]^f\ar[dr]&&y\\
+	&\Im f\ar[ru]
+	&&&&\Coim f\ar@{-->}[ru]_{\exists!}&
+}
+$$
+
 \begin{lemma}
 \label{lemma-characterize-injective}
 Let $f : x \to y$ be a morphism in a preabelian category $\mathcal{A}$. The following are equivalent:
@@ -544,13 +554,24 @@ Let $f : x \to y$ be a morphism in a preabelian category $\mathcal{A}$. The foll
 \item $x\to \Coim(f)$ is an isomorphism, and
 \item $f$ is a monomorphism.
 \end{enumerate}
-Dually, the following are also equivalent:
+If further $\mathcal{A}$ is abelian, the previous are equivalent to
+\begin{enumerate}
+	\item[(6)] The canonical map $x\to\Im f$ is an isomorphism,
+	\item[(7)] $\Im f=x$ (in the sense that $f$ is its own image).
+\end{enumerate}
+
+Dually, for $\mathcal{A}$ preabelian, the following are also equivalent:
 \begin{enumerate}
 	\item[(1')] $f$ is surjective,
 	\item[(2')] $y\to\Coker(f)$ is the zero map,
 	\item[(3')] $\Im(f)=y$,
 	\item[(4')] $\Im(f)\to y$ is an isomorphism, and
 	\item[(5')] $f$ is an epimorphism.
+\end{enumerate}
+If further $\mathcal{A}$ is abelian, the previous are equivalent to
+\begin{enumerate}
+	\item[(6')] The canonical map $\Coim f\to y$ is an isomorphism,
+	\item[(7')] $\Coim f=y$ (in the sense that $f$ is its own coimage).
 \end{enumerate}
 \end{lemma}
 
@@ -579,21 +600,33 @@ is a coequalizer diagram, from $\Ker(f)=0$ we deduce $x=\Coim(f)$.
 
 (4)$\Rightarrow$(2). Denote $i:\Ker(f)\to x$ and $p:x\to\Coim(f)$. Since $p$ is a cokernel of $i$, we have $p\circ i=0$. Thus, composing on the left with the inverse of $p$, we get $i=0$.
 
-The proof of the other equivalences is similar.
-\end{proof}
+Now suppose $\mathcal{A}$ is abelian.
 
-\noindent A morphism $f:x\to y$ in a preabelian category factors canonically through $\Im f$ and through $\Coim f$. This is because the composites $x\xrightarrow{f}y\to\Coker f$ and $\Ker f\to x\xrightarrow{f} y$ are always zero.
+(4)$\Leftrightarrow$(6) The image-coimage factorization of $f$ is
 $$
 \xymatrix{
-x\ar[rr]^f\ar@{-->}[dr]_{\exists!}&&y&&
-x\ar[rr]^f\ar[dr]&&y\\
-&\Im f\ar[ru]
-&&&&\Coim f\ar@{-->}[ru]_{\exists!}&
+x\ar[r]^f\ar[d]&y\\
+\Coim f\ar[r]^\cong&\Im f\ar[u]
 }
 $$
+By the uniqueness of the image factorization, the left-bottom composite of this diagram must coincide with the canonical morphism $x\to\Im f$. Then we have that $x\to\Coim f$ is an isomorphism if and only if the composite $x\to\Coim f\xrightarrow{\cong}\Im f$ is an isomorphism.
+
+(6)$\Rightarrow$(7) Since the diagram
+$$
+\xymatrix{
+	x\ar[rr]^f\ar[dr]_{\cong}&&y\\
+	&\Im f\ar[ru]&
+}
+$$
+commutes, $f$ and $\Im f\to y$ are isomorphic as objects over $y$. Thus $f$ is its own image.
+
+(7)$\Rightarrow$(6) By uniqueness of the image factorization, the canonical morphism $x\to\Im f=x$ must be the identity.f
+
+The proof of the other equivalences is dual.
+\end{proof}
 
 \noindent
-Recall Definition \ref{definition-normal-mono-epi} of normal monos and epis. We will need the following lemma to after give the characterization of abelian categories.
+Recall Definition \ref{definition-normal-mono-epi} of normal monos and epis and the canonical factorization through the (co)image explained before Lemma \ref{lemma-characterize-injective}. We will need the following lemma to after give the characterization of abelian categories.
 \begin{lemma}\label{lemma-all-epis-normal-coim-map-monic}
 	Let $\mathcal{A}$ be a preabelian category and let $f:x\to y$ be a morphism of $\mathcal{A}$. Suppose all epis of $\mathcal{A}$ are normal. Then the canonical map $i:\Coim f\to y$ is monic. Dually, if all monos of $\mathcal{A}$ are normal, then the canonical map $x\to\Im f$ is epic.
 \end{lemma}
@@ -681,7 +714,7 @@ The zero map can be detected by the (co)kernel and the (co)image.
 	
 	(5)$\Rightarrow$(6). Since $y\to\Coker f$ is an isomorphism, in particular it is a monomorphism, and, thus, it has trivial kernel by Lemma \ref{lemma-characterize-injective}. That is, $\Im f=0$.
 	
-	(6)$\Leftrightarrow$(7). It's 1$\Leftrightarrow$2 from Lemma \ref{lemma-characterize-injective}.
+	(6)$\Leftrightarrow$(7). It's (1)$\Leftrightarrow$(2) from Lemma \ref{lemma-characterize-injective}.
 	
 	(6)$\Rightarrow$(5). $\Im f=0$ means that $y\to \Coker f$ has trivial kernel, and so it is a monomorphism, by Lemma \ref{lemma-characterize-injective}. But since it is also a regular epimorphism, it is an isomorphism.
 	
@@ -759,16 +792,81 @@ $$
 0 \to A  \to B \to C \to 0.
 $$
 \end{definition}
-Note that in the definition of exact sequence we may drop the complex condition if $\mathcal{A}$ is preabelian. Indeed, if $x\xrightarrow{f}y\xrightarrow{g}z$ is such that $\Im f=\Ker g$, then, by the image-coimage factorization of $f$ we have a commutative diagram
+Note that in the definition of exact sequence we may drop the complex condition. Indeed, if $x\xrightarrow{f}y\xrightarrow{g}z$ is such that $\Im f=\Ker g$, then, by the factorization of $f$ through its image, we have a commutative diagram
 $$
 \xymatrix{
-x\ar[r]^f\ar[d]&y\ar[r]^g&z\\
-\Coim f\ar[r]&\Im f=\Ker g\ar[u]&
+x\ar[r]^f\ar[dr]&y\ar[r]^g&z\\
+&\Im f=\Ker g\ar[u]&&
 }
 $$
 and so, it follows that $gf=0$ since the composite $\Ker g\to y\xrightarrow{g}z$ is zero. Thus, any exact sequence of morphisms in a preabelian category must be a complex.
+
+\begin{lemma}\label{lemma-exact-self-dual}
+	Exactness is a self-dual property: if $x\xrightarrow{f}y\xrightarrow{g}y$ is a sequence on some additive category $\mathcal{A}$, then it is exact if and only the dual sequence on $\mathcal{A}^\mathrm{op}$ is exact. Specifically, $\operatorname{im}f$ and $\ker g$ exist and they are equal if and only if $\operatorname{coker}f$ and $\operatorname{coim}g$ exist and they are equal.
+\end{lemma}
+
+\begin{proof}
+	It suffices to prove one implication, for the other implication follows by a duality argument.
+	
+	If $\operatorname{im}f=\ker(\operatorname{coker}f)$ exists, then it is because in particular $\operatorname{coker}f$ exists as well. Now suppose $\ker g$ also exists and $\operatorname{im}f=\ker g$. We claim that $\operatorname{coker}f$ is a coimage of $g$. Let $h:y\to w$ be such that $hi=0$, where $i:\Im f=\Ker g\to y$ is the inclusion.
+	$$
+	\xymatrix{
+	&\Coker f\ar@{-->}[r]&w\\
+	x\ar[r]^f\ar[rd]_{f'}&y\ar[r]_g\ar[ru]_h\ar[u]&z\\
+	&\Im f =\Ker g\ar[u]_i&
+	}
+	$$
+	Let $f':x\to\Im f$ be the canonical factorization of $f$ through its image. Then we have $hf=hif'=0f'=0$. Therefore, $h$ factors through $\Coker f$ by a unique morphism $\Coker f\to w$. This shows that $y\to\Coker f$ is a coimage of $g$.
+\end{proof}
+
+\begin{remark}\label{remark-characterize-injective-exact-sequence}
+	In a preabelian category a morphism $f:x\to y$ is injective (resp., surjective) if and only if $0\to x\xrightarrow{f}y$ is exact (resp., if $ x\xrightarrow{f}y\to 0$ is exact). This follows from lemmas \ref{lemma-characterize-injective} and \ref{lemma-characterize-zero-map}. If the category in question is also abelian, then exact sequences can also encapsulate the property of being a isomorphism or a (co)kernel:
+	\begin{enumerate}
+		\item[(i)] Since on this case all monos and epis will be normal (and thus regular), by Lemma \ref{lemma-characterize-iso} it follows that $f$ is an isomorphism if and only if $0\to x\xrightarrow{f}y\to 0$ is exact.
+		\item[(ii)] A morphism $f:x\to y$ will be a kernel of the morphism $g:y\to z$ if and only if the sequence $0\to x\xrightarrow{f}y\xrightarrow{g}z$ is exact, by lemmas \ref{lemma-characterize-injective} and \ref{lemma-kernel-mono}.
+		\item[(iii)] By a duality argument and since exactness is a self-dual property (Lemma \ref{lemma-exact-self-dual}), from (ii) it follows that a morphism $g:y\to z$ will be a cokernel of the morphism $f:x\to y$ if and only if the sequence $x\xrightarrow{f}y\xrightarrow{g}z\to 0$ is exact.
+	\end{enumerate}
+\end{remark}
+
+\begin{lemma}
+	\begin{slogan}
+		In a complex from an abelian category, the image of a morphism is a subobject of the kernel of the next morphism.
+	\end{slogan}
+	Let $x\xrightarrow{f}y\xrightarrow{g}z$ be a sequence in an abelian category. The sequence is a complex if and only if there exists a morphism $i':\Im f\to\ker g$ such that the diagram
+	$$
+	\xymatrix{
+	x\ar[r]^f\ar[d]&y\\
+	\Im f\ar[r]^{i'}&\Ker g\ar[u]	
+	}
+	$$
+	is commutative, where $x\to\Im f$ is the canonical morphism. Moreover, such a morphism $i'$ is unique and monic, and we have that $x\xrightarrow{f}y\xrightarrow{g}z$ is exact if and only if $i'$ is an isomorphism.
+\end{lemma}
+
+\begin{proof}
+	($\Leftarrow$) If there exists such a factorization of $f$, then $gf$ equals the composite $x\to\Im f\to\Ker g\to y\xrightarrow{g}z$. But the composite $\Ker g\to y\xrightarrow{g}z$ is zero.
+	
+	($\Rightarrow$) Suppose the sequence is a complex.
+	$$
+	\xymatrix{
+	x\ar[r]^f\ar[d]_{f'}&y\ar[r]^g&z\\
+	\Im f\ar[ru]^i\ar@{-->}[r]_{i'}&\Ker g\ar[u]_j
+	}
+	$$
+	Then we have $0=gf=gif'$. Since $f'$ is epic (Lemma \ref{lemma-all-epis-normal-coim-map-monic}), we deduce $0=gi$. Therefore $i$ factors as $i=ji'$. Since $i$ is monic (it is a normal monomorphism), by Lemma \ref{lemma-new-mono-epi-from-old} we deduce that $i'$ is also monic.
+	
+	Uniqueness of $i'$ follows from the fact that $f'$ is epic and $j$ is monic, and we've proven that $i'$ must be a monomorphism.
+	
+	On the other hand, if $x\xrightarrow{f}y\xrightarrow{g}z$ is exact, $\Im f=\Ker g$, then $i'$ must be the identity. And if $i'$ is an isomorphism, then by the factorization $i=ji'$, we have that $\Im f$ and $\Ker g$ are isomorphic as objects over $y$, so $\Im f=\Ker g$.
+\end{proof}
 \begin{remark}
-	In a preabelian category a morphism $f:x\to y$ is injective (resp., surjective) if and only if $0\to x\xrightarrow{f}y$ is exact (resp., if $ x\xrightarrow{f}y\to 0$ is exact). This follows from lemmas \ref{lemma-characterize-injective} and \ref{lemma-characterize-zero-map}. If the category in question is also abelian, then, since on that case all monos and epis will be normal (and thus regular), by Lemma \ref{lemma-characterize-iso} it follows that $f$ is an isomorphism if and only if $0\to x\xrightarrow{f}y\to 0$ is exact.
+	Since ``being a complex'' and ``being exact'' are self-dual properties, one can obtain a dual result from the last lemma, which now is stated for a commutative diagram of the form
+	$$
+	\xymatrix{
+	x\ar[r]^f&y\ar[d]\ar[r]^g&z\\
+	&\Coker f\ar[r]&\Coim g\ar[u]
+	}
+	$$
+	where $\Coker f\to\Coim g$ is epic.
 \end{remark}
 
 \noindent

--- a/homology.tex
+++ b/homology.tex
@@ -70,21 +70,19 @@ one morphism $x \to y$, namely the zero map.
 \label{lemma-preadditive-zero}
 Let $\mathcal{A}$ be a preadditive category.
 Let $x$ be an object of $\mathcal{A}$.
-The following are equivalent
+The following are equivalent:
 \begin{enumerate}
 \item $x$ is an initial object,
-\item $x$ is a final object, and
-\item $\text{id}_x = 0$ in $\Mor_\mathcal{A}(x, x)$.
+\item $x$ is a final object,
+\item $\Mor_\mathcal{A}(x,x)$ is the trivial abelian group, and
+\item $\operatorname{id}_x = 0$ in $\Mor_\mathcal{A}(x, x)$.
 \end{enumerate}
 Furthermore, if such an object $0$ exists, then a morphism
 $\alpha : x \to y$ factors through $0$ if and only if $\alpha = 0$.
 \end{lemma}
 
 \begin{proof}
-First assume that $x$ is either (1) initial or (2) final.
-In both cases, it follows that $\Mor(x,x)$ is a trivial abelian group
-containing $\text{id}_x$, thus $\text{id}_x = 0$ in
-$\Mor(x, x)$, which shows that each of (1) and (2) implies (3).
+It is clear that (1) or (2) implies (3), and that (3) implies (4).
 
 \medskip\noindent
 Now assume that $\text{id}_x = 0$ in $\Mor(x,x)$. Let $y$
@@ -93,7 +91,7 @@ Denote $C : \Mor(x,x) \times \Mor(x,y) \to \Mor(x,y)$ the composition map.
 Then $f = C(0, f)$ and since $C$ is bilinear we have $C(0, f) = 0$.
 Thus $f = 0$. Hence $x$ is initial in $\mathcal{A}$.
 A similar argument for $f \in \Mor(y, x)$ can be used to show that
-$x$ is also final. Thus (3) implies both (1) and (2).
+$x$ is also final. Thus (4) implies both (1) and (2).
 \end{proof}
 
 \begin{definition}
@@ -191,7 +189,7 @@ Hence, $F$ transforms direct sums to direct sums.
 
 \medskip\noindent
 To see that $F$ transforms zero to zero, use the
-characterization (3) of the zero object in
+characterization (4) of the zero object in
 Lemma \ref{lemma-preadditive-zero}.
 \end{proof}
 
@@ -243,8 +241,7 @@ up to unique isomorphism. This follows from the Yoneda lemma
 (Categories, Section \ref{categories-section-opposite})
 because the kernel of $f : x \to y$ represents the functor
 sending an object $z$ to the set
-$\Ker(\Mor_\mathcal{A}(z, x) \to \Mor_\mathcal{A}(z, y))$.
-The case of cokernels is dual.
+$\Ker(\Mor_\mathcal{A}(z, x) \to \Mor_\mathcal{A}(z, y))$. Dually, the cokernel of $f:x\to y$ represents the functor sending an object $w$ to the set $\Ker(\Mor_\mathcal{A}(y,w) \to \Mor_\mathcal{A}(x,w))$.
 
 \medskip\noindent
 We first relate the direct sum to kernels as follows.
@@ -576,8 +573,8 @@ in $\mathcal{A}$. We say such a sequence is a {\it complex} if the
 composition of any two consecutive (drawn) arrows is zero.
 If $\mathcal{A}$ is abelian then we say a complex of the first
 type above is {\it exact at $y$} if $\Im(x \to y) = \Ker(y \to z)$
-and we say a complex of the second kind is {\it exact at $x_i$}
-where $1 < i < n$ if
+and we say a complex of the second kind is {\it exact at $x_i$,}
+where $1 < i < n$, if
 $\Im(x_{i - 1} \to x_i) = \Ker(x_i \to x_{i + 1})$. We a
 sequence as above is {\it exact} or is an {\it exact sequence} or is an
 {\it exact complex} if it is a complex and exact at every object (in
@@ -1314,56 +1311,96 @@ or pullback of the given short exact sequence.
 \label{section-functors}
 
 \noindent
-First a completely silly lemma characterizing additive functors
+Given morphisms $f:A\to A'$ and $g:B\to B'$ in an additive category, we denote $f\oplus g:A\oplus B\to A'\oplus B'$ to the morphism $i'\circ f\circ p+j'\circ g\circ q$, where $i',j'$ are the inclusions of $A'$ and $B'$ into $A'\oplus B'$, respectively, and $p,q$ are the projections from $A\oplus B$ into $A$ and $B$, respectively. That is, $f\oplus g$ equals the morphism
+\begin{equation}\label{equation-direct-sum-morphisms}
+	\begin{aligned}
+		(f\times 0)\amalg(0\times g)
+		&=(i'\circ f)\amalg(j'\circ g)\\
+		&=i'\circ f\circ p+j'\circ g\circ q\\
+		&=(f\circ p)\times (g\circ q)\\
+		&=(f\amalg 0)\times(0\amalg g).
+	\end{aligned}
+\end{equation}
+Note that, with this definition, $\operatorname{id}_A\oplus\operatorname{id}_B=\operatorname{id}_{A\oplus B}$.
+
+First we see a completely silly lemma characterizing additive functors
 between additive categories.
 
 \begin{lemma}
 \label{lemma-additive-functor}
 Let $\mathcal{A}$ and $\mathcal{B}$ be additive categories.
 Let $F : \mathcal{A} \to \mathcal{B}$ be a functor.
-The following are equivalent
+The following are equivalent:
 \begin{enumerate}
 \item $F$ is additive,
-\item $F(A) \oplus F(B) \to F(A \oplus B)$ is an isomorphism for
+\item $F$ commutes with coproducts, i.e., $F(A) \oplus F(B) \xrightarrow{Fi\amalg Fj} F(A \oplus B)$ is an isomorphism for
+all $A, B \in \mathcal{A}$,
+\item $F$ commutes with products, i.e., $F(A \oplus B) \xrightarrow{Fp\times Fq} F(A) \oplus F(B)$ is an isomorphism for
 all $A, B \in \mathcal{A}$, and
-\item $F(A \oplus B) \to F(A) \oplus F(B)$  is an isomorphism for
-all $A, B \in \mathcal{A}$.
+\item $F$ commutes with direct sums. That is, if $(A\oplus B, i, j,p,q)$ is a direct sum of $A,B\in\mathcal{A}$, then $(F(A\oplus B),F(i),F(j),F(p),F(q))$ is a direct sum of $F(A),F(B)\in\mathcal{B}$. 
 \end{enumerate}
 \end{lemma}
 
 \begin{proof}
-Additive functors commute with direct sums by
-Lemma \ref{lemma-additive-additive} hence (1)
-implies (2) and (3). On the other hand (2) and (3)
-are equivalent because the composition
-$F(A) \oplus F(B) \to F(A \oplus B) \to F(A) \oplus F(B)$
-is the identity map. Assume (2) and (3) hold.
-Let $f, g : A \to B$ be maps. Then $f + g$ is equal to
-the composition
+(1)$\Rightarrow$(4). It is the content of Lemma \ref{lemma-additive-additive}.
+
+(2)$\Leftrightarrow$(3). Suppose we've proven the claim
+\begin{equation}\tag{*}\label{equation-aux-claim}
+	\text{(2) or (3) implies that $F$ preserves the zero object, }F(0)=0.
+\end{equation} (Note that a functor preserves the zero object if and only if it preserves zero maps.) Then, using
+\begin{enumerate}
+	\item[(i)] the general identities $g\circ(f\amalg f')=(g\circ f)\amalg (g\circ f')$ and $(f\times f')\circ h=(f\circ h)\times (f'\circ h)$,
+	\item[(ii)] the identities from Remark \ref{remark-direct-sum},
+	\item[(iii)] the fact that $F$ preserves zero maps by \eqref{equation-aux-claim}, and
+	\item[(iv)] the definition of the direct sum of morphisms in \eqref{equation-direct-sum-morphisms},
+\end{enumerate}
+it is not difficult to verify that the composite
 $$
-A \to A \oplus A \xrightarrow{\text{diag}(f, g)} B \oplus B \to B
+F(A) \oplus F(B) \xrightarrow{Fi\amalg Fj} F(A \oplus B) \xrightarrow{Fp\times Fq} F(A) \oplus F(B)
 $$
+equals the identity map. From this fact it follows that (2)$\Leftrightarrow$(3). It is left to prove the claim \eqref{equation-aux-claim}. Suppose (3) holds. By Lemma \ref{lemma-preadditive-zero}, it suffices to verify that $F(0)$ is terminal. If $B\in\mathcal{B}$, then there is at least one map $B\to F(0)$ (the zero map), since $\mathcal{B}$ is preadditive. Now let $f,g:B\to F(0)$ be maps. The morphism $f-g$ equals the composite
+$$
+B\xrightarrow{f\times g}F(0)\oplus F(0)\xrightarrow{p'_1-p'_2} F(0),
+$$
+where $p_1',p_2':F(0)\oplus F(0)\to F(0)$ are the projections. Since $0\oplus 0=0$ is an initial object, the projections $p_1,p_2:0\oplus 0\to 0$ satisfy $p_1=p_2$. Thus, since the diagram
+$$
+\xymatrix{
+	F(0\oplus 0)\ar[rr]^{Fp_1\times Fp_2}\ar[dr]_{Fp_i}
+	&&F(0)\oplus F(0)\ar[dl]^{p_i'}\\
+	&F(0)&
+}
+$$
+commutes, for $i=1,2$, and $Fp_1\times Fp_2$ is an isomorphism, it follows that $p_1'=p_2'$. Therefore $f-g=(p_1'-p_2')\circ(f\times g)=0\circ(f\times g)=0$. Hence, $F(0)$ is terminal in $\mathcal{B}$. Dually, from (2) one can show that $F(0)$ is an initial object. This proves the claim \eqref{equation-aux-claim}.
+
+(2)+(3) $\Leftrightarrow$ (4). The implication to the right is clear. The implication to the left also holds because in a preadditive category any coproduct and any product is also a direct sum (Lemma \ref{lemma-preadditive-direct-sum}).
+
+(2)+(3) $\Rightarrow$ (1). Let $f, g : A \to B$ be maps. Then, using \eqref{equation-direct-sum-morphisms} we see that the morphism $f + g$ equals the composite
+$$
+A \xrightarrow{\Delta_A} A \oplus A \xrightarrow{f\oplus g} B \oplus B \xrightarrow{\nabla_B} B,
+$$
+where $\Delta_A=\operatorname{id}_A\times\operatorname{id}_A$ and $\nabla_B=\operatorname{id}_B\amalg\operatorname{id}_B$ denote the diagonal and codiagonal morphisms, respectively.
 Apply the functor $F$ and consider the following diagram
 $$
 \xymatrix{
-F(A) \ar[r] \ar[rd] &
-F(A \oplus A) \ar[rr]_{F(\text{diag}(f, g))} & &
-F(B \oplus B) \ar[r] \ar[d] &
+F(A) \ar[r]^{F(\Delta_A)} \ar[rd]_{\Delta_{F(A)}} &
+F(A \oplus A) \ar[rr]^{F(f\oplus g)} & &
+F(B \oplus B) \ar[r]^{F(\nabla_B)} \ar[d]_{Fq_1\times Fq_2} &
 F(B) \\
 &
-F(A) \oplus F(A) \ar[u] \ar[rr]^{\text{diag}(F(f), F(g))} & &
-F(B) \oplus F(B) \ar[ru]
+F(A) \oplus F(A) \ar[u]_{Fi_1\amalg Fi_2} \ar[rr]_{F(f)\oplus F(g)} & &
+F(B) \oplus F(B) \ar[ru]_{\nabla_{F(B)}}
 }
 $$
-We claim this is commutative. For the middle square we can verify it
-separately for each of the four induced maps $F(A) \to F(B)$
-where it follows from the fact that $F$ is a functor (in other words
-this square commutes even if $F$ does not satisfy any properties
-beyond being a functor). For the triangle on the left, we use that
-$F(A \oplus A) \to F(A) \oplus F(A)$ is an isomorphism
-to see that it suffice to check after composition with
-this map and this check is trivial. Dually for the other triangle.
-Thus going around the bottom is equal to $F(f + g)$ and we conclude.
+Here $i_1,i_2:A\to A\oplus A$ are the inclusions and $q_1,q_2:B\oplus B\to B$ are the projections. We claim this diagram is commutative. Commutativity of the middle square can be verified using the facts (i) to (iv) from the proof of (2)$\Leftrightarrow$(3). For commutativity of the left and right triangles, first note that using again facts (i) to (iv) from proof of (2)$\Leftrightarrow$(3), it is easy to verify that $Fp_1\times Fp_2$ is a left inverse of $Fi_1\amalg Fi_2$, and, thus, it must be \emph{the} inverse, for (2) and (3) hold. Therefore, to verify commutativity of the left triangle:
+\begin{align*}
+	(Fp_1\times Fp_2)\circ F\Delta_A
+	&=(Fp_1\circ F\Delta_A)\times(Fp_2\circ F\Delta_A)\\
+	&=F(p_1\Delta_A)\times F(p_2\Delta_A)\\
+	&=F\operatorname{id}_A\times F\operatorname{id}_A\\
+	&=\operatorname{id}_{FA}\times\operatorname{id}_{FA}\\
+	&=\Delta_{FA}.
+\end{align*}
+Dually, the right triangle commutes. Thus, the top composite in the diagram equals the bottom one. That is, we have that $F(f + g)=Ff+Fg$, and we conclude.
 \end{proof}
 
 \noindent

--- a/homology.tex
+++ b/homology.tex
@@ -213,14 +213,24 @@ Let $f : x \to y$ be a morphism.
 $i : z \to x$ such that (a) $f \circ i = 0$ and (b)
 for any $i' : z' \to x$ such that $f \circ i' = 0$ there
 exists a unique morphism $g : z' \to z$ such that
-$i' = i \circ g$.
+$i' = i \circ g$. Equivalently, $i:z\to x$ is a kernel of $f:x\to y$ if it is the equalizer of
+$
+\xymatrix@C=3.5ex{
+x\ar@<0.5ex>[r]^f\ar@<-0.5ex>[r]_0&y.
+}
+$
 \item If the kernel of $f$ exists, then we denote
 this $\Ker(f) \to x$.
 \item A {\it cokernel} of $f$ is a morphism
 $p : y \to z$ such that (a) $p \circ f = 0$ and (b)
 for any $p' : y \to z'$ such that $p' \circ f = 0$ there
 exists a unique morphism $g : z \to z'$ such that
-$p' = g \circ p$.
+$p' = g \circ p$. Equivalently, $p:y\to z$ is a cokernel of $f:x\to y$ if it is the coequalizer of
+$
+\xymatrix@C=3.5ex{
+	x\ar@<0.5ex>[r]^f\ar@<-0.5ex>[r]_0&y.
+}
+$
 \item If a cokernel of $f$ exists we denote this
 $y \to \Coker(f)$.
 \item If a kernel of $f$ exists, then a {\it coimage
@@ -237,8 +247,8 @@ this $\Im(f) \to y$.
 \noindent
 In the above definition, we have spoken of ``the kernel'' and
 ``the cokernel'', tacitly using their uniqueness
-up to unique isomorphism. This follows from the Yoneda lemma
-(Categories, Section \ref{categories-section-opposite})
+up to unique isomorphism. This follows from the essential uniqueness of a (co)limit, since a (co)kernel is a (co)equalizer. This uniqueness can be also verified via the Yoneda lemma
+(Categories, Section \ref{categories-section-opposite}),
 because the kernel of $f : x \to y$ represents the functor
 sending an object $z$ to the set
 $\Ker(\Mor_\mathcal{A}(z, x) \to \Mor_\mathcal{A}(z, y))$. Dually, the cokernel of $f:x\to y$ represents the functor sending an object $w$ to the set $\Ker(\Mor_\mathcal{A}(y,w) \to \Mor_\mathcal{A}(x,w))$.
@@ -301,8 +311,7 @@ the image is a monomorphism.
 \end{lemma}
 
 \begin{proof}
-Part (1) follows easily from the uniqueness required in the
-definition of a kernel. The proof of (2) is dual.
+Part (1) follows from the fact that an equalizer is always monic. Dually, (2) follows from the fact that a coequalizer is epic.
 Part (3) follows from (2), since the coimage is a cokernel.
 Similarly, (4) follows from (1).
 \end{proof}
@@ -521,22 +530,93 @@ surjective, then we say that $y$ is a {\it quotient} of $x$.
 
 \begin{lemma}
 \label{lemma-characterize-injective}
-Let $f : x \to y$ be a morphism in an abelian category $\mathcal{A}$. Then
+Let $f : x \to y$ be a morphism in an abelian category $\mathcal{A}$. The following are equivalent:
 \begin{enumerate}
-\item $f$ is injective if and only if $f$ is a monomorphism, and
-\item $f$ is surjective if and only if $f$ is an epimorphism.
+\item $f$ is injective,
+\item $\Ker(f)\to x$ is the zero map,
+\item $\Coim(f)=x$,
+\item $x\to \Coim(f)$ is an isomorphism, and
+\item $f$ is a monomorphism.
+\end{enumerate}
+Dually, the following are also equivalent:
+\begin{enumerate}
+	\item[(1')] $f$ is surjective,
+	\item[(2')] $y\to\Coker(f)$ is the zero map,
+	\item[(3')] $\Im(f)=y$,
+	\item[(4')] $\Im(f)\to y$ is an isomorphism, and
+	\item[(5')] $f$ is an epimorphism.
 \end{enumerate}
 \end{lemma}
 
 \begin{proof}
-Proof of (1). Recall that $\Ker(f)$ is an object representing the
+(1)$\Leftrightarrow$(5). Recall that $\Ker(f)$ is an object representing the
 functor sending $z$ to
 $\Ker(\Mor_\mathcal{A}(z, x) \to \Mor_\mathcal{A}(z, y))$, see
 Definition \ref{definition-kernel}.
 Thus $\Ker(f)$ is $0$ if and only if
 $\Mor_\mathcal{A}(z, x) \to \Mor_\mathcal{A}(z, y)$
 is injective for all $z$ if and only if $f$ is a monomorphism.
-The proof of (2) is similar.
+
+(1)$\Rightarrow$(2). Clear.
+
+(2)$\Rightarrow$(1). If $g:z\to x$ is such that $f\circ g=0$, then $g$ factors through the zero map $\Ker(f)\to x$, and thus $g=0$. That is, $g$ factors uniquely through $0\to x$. Hence, $0$ is a kernel of $f$.
+
+(1)$\Rightarrow$(3). Since the diagram
+$
+\xymatrix@C=3.5ex{
+	0\ar@<0.5ex>[r]\ar@<-0.5ex>[r]&x\ar[r]&x
+}
+$
+is a coequalizer diagram, from $\Ker(f)=0$ we deduce $x=\Coim(f)$.
+
+(3)$\Rightarrow$(4). It's clear.
+
+(4)$\Rightarrow$(2). Denote $i:\Ker(f)\to x$ and $p:x\to\Coim(f)$. Since $p$ is a cokernel of $i$, we have $p\circ i=0$. Thus, composing on the left with the inverse of $p$, we get $i=0$.
+
+The proof of the other equivalences is similar.
+\end{proof}
+\noindent
+The zero map can be detected by the (co)kernel and the (co)image.
+\begin{lemma}\label{lemma-characterize-zero-map}
+	Let $\mathcal{A}$ be a abelian category and let $f:x\to y$ be a morphism in $\mathcal{A}$. The following are equivalent:
+	\begin{enumerate}
+		\item $f$ is the zero map,
+		\item $\Ker f=x$,
+		\item $\Ker f\to x$ is an isomorphism,
+		\item $\Coker f=y$,
+		\item $y\to\Coker f$ is an isomorphism,
+		\item $\Im f=0$,
+		\item $\Im f\to y$ is the zero map,
+		\item $\Coim f=0$, and
+		\item $x\to\Coim f$ is the zero map.
+	\end{enumerate}
+\end{lemma}
+\begin{proof}
+	(1)$\Rightarrow$(2). Since the diagram
+	$
+	\xymatrix@C=3.5ex{x\ar[r]&
+		x\ar@<0.5ex>[r]^0\ar@<-0.5ex>[r]_0&y
+	}
+	$
+	is always an equalizer diagram, we conclude that $f=0$ implies $\Ker f=x$.
+	
+	(2)$\Rightarrow$(3). Clear.
+	
+	(3)$\Rightarrow$(1). Call $i:\Ker f\to x$ to the inclusion. Then $f\circ i=0$, and since $i$ is an isomorphism, $f=0$.
+	
+	The implications $(1)\Rightarrow (4)\Rightarrow (5)\Rightarrow (1)$ are similar.
+	
+	(5)$\Rightarrow$(6). Since $y\to\Coker f$ is an isomorphism, in particular it is a monomorphism, and, thus, it has trivial kernel by Lemma \ref{lemma-characterize-injective}. That is, $\Im f=0$.
+	
+	(6)$\Leftrightarrow$(7). It's 1$\Leftrightarrow$2 from Lemma \ref{lemma-characterize-injective}.
+	
+	(6)$\Rightarrow$(5). $\Im f=0$ means that $y\to \Coker f$ has trivial kernel, and so it is a monomorphism, by Lemma \ref{lemma-characterize-injective}. But since it is also a regular epimorphism, it is an isomorphism.
+	
+	(8)$\Leftrightarrow$(9). It's (1')$\Leftrightarrow$(2') from Lemma \ref{lemma-characterize-injective}.
+	
+	(3)$\Rightarrow$(8). By (5')$\Leftrightarrow$(1') from Lemma \ref{lemma-characterize-injective}.
+	
+	(8)$\Rightarrow$(3) We have that $\Ker f\to x$ is a regular monomorphism and also epic. Hence, it is iso.
 \end{proof}
 
 \noindent
@@ -606,6 +686,9 @@ $$
 0 \to A  \to B \to C \to 0.
 $$
 \end{definition}
+\begin{remark}
+	In an abelian category a morphism $f:x\to y$ is injective (resp., surjective) if and only if $0\to x\xrightarrow{f}y$ is exact (resp., if $ x\xrightarrow{f}y\to 0$ is exact). This follows from lemmas \ref{lemma-characterize-injective} and \ref{lemma-characterize-zero-map}.
+\end{remark}
 
 \noindent
 In the following lemma we assume the reader knows what it means
@@ -1451,9 +1534,7 @@ is exact.
 \end{lemma}
 
 \begin{proof}
-If $F$ is left exact, i.e., $F$ commutes with finite limits, then
-$F$ sends products to products, hence $F$ preserved direct sums,
-hence $F$ is additive by Lemma \ref{lemma-additive-functor}.
+$F$ being left (right) exact means $F$ commutes with finite (co)limits, and in particular, $F$ commutes with finite (co)products. Thus, on either case $F$ is additive by Lemma \ref{lemma-additive-functor}.
 On the other hand, suppose that for every short exact sequence
 $0 \to A \to B \to C \to 0$ the sequence $0 \to F(A) \to F(B) \to F(C)$
 is exact. Let $A, B$ be two objects. Then we have a short

--- a/homology.tex
+++ b/homology.tex
@@ -315,6 +315,10 @@ Part (1) follows from the fact that an equalizer is always monic. Dually, (2) fo
 Part (3) follows from (2), since the coimage is a cokernel.
 Similarly, (4) follows from (1).
 \end{proof}
+\begin{definition}\label{definition-normal-mono-epi}
+	Let $\mathcal{A}$ be a preadditive category and let $f:x\to y$ be a morphism in $\mathcal{A}$. We say that $f$ is a {\it normal monomorphism} if it arises as the kernel of some other morphism. That is, if there is $g:y\to z$ in $\mathcal{A}$ such that $\ker g=f$. Dually, we say that $f$ is a {\it normal epimorphism} if it is a cokernel, i.e., if there is $h:w\to x$ such that $\operatorname{coker} h=f$.
+\end{definition}
+Every normal monomorphism or normal epimorphism is, respectively, indeed monic and epic, by Lemma \ref{lemma-kernel-mono}.
 
 \begin{lemma}
 \label{lemma-coim-im-map}
@@ -485,9 +489,8 @@ Example \ref{example-not-abelian} shows that it is necessary.
 
 \begin{definition}
 \label{definition-abelian-category}
-A category $\mathcal{A}$ is {\it abelian} if
-it is additive, if all kernels and cokernels exist,
-and if the natural map $\Coim(f) \to \Im(f)$
+A category $\mathcal{A}$ is {\it preabelian} if
+it is additive and if all kernels and cokernels exist. And it is called {\it abelian} if it is preabelian and the natural map $\Coim(f) \to \Im(f)$
 is an isomorphism for all morphisms $f$ of
 $\mathcal{A}$.
 \end{definition}
@@ -499,8 +502,11 @@ The additions on sets of morphisms make
 $\mathcal{A}^{opp}$ into a preadditive category.
 Furthermore, $\mathcal{A}$ is additive if and only if $\mathcal{A}^{opp}$
 is additive, and
-$\mathcal{A}$ is abelian if and only if $\mathcal{A}^{opp}$ is abelian.
+$\mathcal{A}$ is (pre)abelian if and only if $\mathcal{A}^{opp}$ is (pre)abelian.
 \end{lemma}
+\begin{slogan}
+	(Pre)abelianity is a self-dual property.
+\end{slogan}
 
 \begin{proof}
 The first statement is straightforward.
@@ -509,8 +515,8 @@ is additive, recall that additivity can be characterized by
 the existence of a zero object and direct sums, which are both
 preserved when passing to the opposite category.
 Finally, to see that
-$\mathcal{A}$ is abelian if and only if $\mathcal{A}^{opp}$ is abelian,
-observes that kernels, cokernels, images and coimages in
+$\mathcal{A}$ is (pre)abelian if and only if $\mathcal{A}^{opp}$ is abelian,
+observe that kernels, cokernels, images and coimages in
 $\mathcal{A}^{opp}$ correspond to
 cokernels, kernels, coimages and images in $\mathcal{A}$,
 respectively.
@@ -518,7 +524,7 @@ respectively.
 
 \begin{definition}
 \label{definition-injective-surjective}
-Let $f : x \to y$ be a morphism in an abelian category.
+Let $f : x \to y$ be a morphism in a preabelian category.
 \begin{enumerate}
 \item We say $f$ is {\it injective} if $\Ker(f) = 0$.
 \item We say $f$ is {\it surjective} if $\Coker(f) = 0$.
@@ -530,7 +536,7 @@ surjective, then we say that $y$ is a {\it quotient} of $x$.
 
 \begin{lemma}
 \label{lemma-characterize-injective}
-Let $f : x \to y$ be a morphism in an abelian category $\mathcal{A}$. The following are equivalent:
+Let $f : x \to y$ be a morphism in a preabelian category $\mathcal{A}$. The following are equivalent:
 \begin{enumerate}
 \item $f$ is injective,
 \item $\Ker(f)\to x$ is the zero map,
@@ -575,10 +581,77 @@ is a coequalizer diagram, from $\Ker(f)=0$ we deduce $x=\Coim(f)$.
 
 The proof of the other equivalences is similar.
 \end{proof}
+
+\noindent A morphism $f:x\to y$ in a preabelian category factors canonically through $\Im f$ and through $\Coim f$. This is because the composites $x\xrightarrow{f}y\to\Coker f$ and $\Ker f\to x\xrightarrow{f} y$ are always zero.
+$$
+\xymatrix{
+x\ar[rr]^f\ar@{-->}[dr]_{\exists!}&&y&&
+x\ar[rr]^f\ar[dr]&&y\\
+&\Im f\ar[ru]
+&&&&\Coim f\ar@{-->}[ru]_{\exists!}&
+}
+$$
+
 \noindent
+Recall Definition \ref{definition-normal-mono-epi} of normal monos and epis. We will need the following lemma to after give the characterization of abelian categories.
+\begin{lemma}\label{lemma-all-epis-normal-coim-map-monic}
+	Let $\mathcal{A}$ be a preabelian category and let $f:x\to y$ be a morphism of $\mathcal{A}$. Suppose all epis of $\mathcal{A}$ are normal. Then the canonical map $i:\Coim f\to y$ is monic. Dually, if all monos of $\mathcal{A}$ are normal, then the canonical map $x\to\Im f$ is epic.
+\end{lemma}
+\begin{proof}
+	To show that $i$ is a monomorphism, let $g:z\to \Coim f$ be such that $ig=0$.
+	$$
+	\xymatrix{
+	x\ar[rr]^f\ar@{>>}[rd]_p&&y\\
+	z\ar[r]_(0.4)g&\Coim f\ar@{>>}[r]_q\ar[ru]_i&\Coker g\ar[u]_j
+	}
+	$$
+	Let $q=\operatorname{coker}x$ and let $j:\Coker g\to y$ be the unique map such that $i=jq$. Since $qp$ is epic (epicness is stable under composition), by hypothesis there exists $h:w\to x$ such that $qp=\operatorname{coker}h$.
+	$$
+	\xymatrix@C=8ex{
+	&\Ker f\ar[d]^k&\\
+	w\ar[r]^h\ar[rd]_0
+	\ar[ru]^{h'}
+	&x\ar@{>>}[r]^(0.4){qp=\operatorname{coker}h}
+	\ar@{>>}[d]^p
+	&\Coker g\ar[dl]^{p'}\\
+	&\Coim f&
+	}
+	$$
+	Now $fh=iph=jqph=j0=0$, so $h$ factors uniquely through $\Ker f$, $h=kh'$. This gives that $ph=pkh'=0h'=0$, so $p$ factors as $p=p'(qp)=(p'q)p$. But $p$ is epic (By Lemma \ref{lemma-kernel-mono}), so $p'q=1_{\Coim f}$. That is, $q$ is a split monomorphism and finally $qg=0$ implies that $g=0$. We have shown that $ig=0$ implies $g=0$ and thus $i$ is a monomorphism.
+	
+	The other part is the dual statement.
+\end{proof}
+
+\begin{lemma}\label{lemma-characterize-abelian-categories}
+	A preabelian category is abelian if and only if all its monos and epis are normal.
+\end{lemma}
+
+\begin{proof}
+	Let $\mathcal{A}$ be a preabelian category.
+	
+	($\Rightarrow$) Let $f:x\to y$ be a monomorphism of $\mathcal{A}$. By Lemma \ref{lemma-characterize-injective}, $x\to\Coim f$ is an isomorphism. Since the diagram
+	$$
+	\xymatrix{
+	x\ar[r]^f\ar[d]_\cong&y\\
+	\Coim f\ar[r]_\cong&\Im f\ar[u]
+	}
+	$$
+	commutes, we have that the morphisms $f:x\to y$ and $\Im f\to y$ are isomorphic as objects over $y$. Thus $f$ is a kernel. Dually, all epis are normal.
+	
+	($\Leftarrow$) By the uniqueness of the image-coimage factorization of $f$ (given in Lemma \ref{lemma-coim-im-map}),
+	\begin{equation}\label{equation-im-coim-map}
+		\xymatrix{
+			x\ar[r]^f\ar[d]_g&y\\
+			\Coim f\ar[r]_{\overline{f}}&\Im f\ar[u]_h
+		}
+	\end{equation}
+	the canonical morphism $x\to\Im f$ (resp., the canonical morphism $\Coim f\to y$) must coincide with the left-bottom composite (resp., the bottom-right composite) of \eqref{equation-im-coim-map}. By Lemma \ref{lemma-all-epis-normal-coim-map-monic}, the composites $\overline{f}g$ and $h\overline{f}$ are epic and monic, respectively. Thus, by Lemma \ref{lemma-new-mono-epi-from-old}, $\overline{f}$ is also epic and monic. By hypothesis, $\overline{f}$ must be a normal monomorphism and a normal epimorphism, and thus in particular a regular mono and epi. By Lemma \ref{lemma-characterize-iso}, $\overline{f}$ is an isomorphism.
+\end{proof}
+From lemmas \ref{lemma-characterize-injective}, \ref{lemma-characterize-abelian-categories}, and \ref{lemma-characterize-iso}, it follows that in an abelian category a morphism is an isomorphism if and only if it is injective and surjective (i.e., an abelian category is an example of what category theorists call a {\it balanced category}). However, this condition does not characterize abelianity: there exist preabelian categories which are balanced but not abelian. For an example, see \href{https://mathoverflow.net/a/41726/101848}{this}.
+
 The zero map can be detected by the (co)kernel and the (co)image.
 \begin{lemma}\label{lemma-characterize-zero-map}
-	Let $\mathcal{A}$ be a abelian category and let $f:x\to y$ be a morphism in $\mathcal{A}$. The following are equivalent:
+	Let $\mathcal{A}$ be a preabelian category and let $f:x\to y$ be a morphism in $\mathcal{A}$. The following are equivalent:
 	\begin{enumerate}
 		\item $f$ is the zero map,
 		\item $\Ker f=x$,
@@ -628,7 +701,7 @@ $$
 
 \begin{lemma}
 \label{lemma-colimit-abelian-category}
-Let $\mathcal{A}$ be an abelian category.
+Let $\mathcal{A}$ be a preabelian category.
 All finite limits and finite colimits exist in $\mathcal{A}$.
 \end{lemma}
 
@@ -644,7 +717,7 @@ is similar but dual to this.
 
 \begin{example}
 \label{example-fibre-product-pushouts}
-Let $\mathcal{A}$ be an abelian category.
+Let $\mathcal{A}$ be a preabelian category.
 Pushouts and fibre products in $\mathcal{A}$ have the following
 simple descriptions:
 \begin{enumerate}
@@ -671,7 +744,7 @@ If $\mathcal{A}$ is abelian then we say a complex of the first
 type above is {\it exact at $y$} if $\Im(x \to y) = \Ker(y \to z)$
 and we say a complex of the second kind is {\it exact at $x_i$,}
 where $1 < i < n$, if
-$\Im(x_{i - 1} \to x_i) = \Ker(x_i \to x_{i + 1})$. We a
+$\Im(x_{i - 1} \to x_i) = \Ker(x_i \to x_{i + 1})$. We say that a
 sequence as above is {\it exact} or is an {\it exact sequence} or is an
 {\it exact complex} if it is a complex and exact at every object (in
 the first case) or exact at $x_i$ for all $1 < i < n$ (in the second case).
@@ -686,8 +759,16 @@ $$
 0 \to A  \to B \to C \to 0.
 $$
 \end{definition}
+Note that in the definition of exact sequence we may drop the complex condition if $\mathcal{A}$ is preabelian. Indeed, if $x\xrightarrow{f}y\xrightarrow{g}z$ is such that $\Im f=\Ker g$, then, by the image-coimage factorization of $f$ we have a commutative diagram
+$$
+\xymatrix{
+x\ar[r]^f\ar[d]&y\ar[r]^g&z\\
+\Coim f\ar[r]&\Im f=\Ker g\ar[u]&
+}
+$$
+and so, it follows that $gf=0$ since the composite $\Ker g\to y\xrightarrow{g}z$ is zero. Thus, any exact sequence of morphisms in a preabelian category must be a complex.
 \begin{remark}
-	In an abelian category a morphism $f:x\to y$ is injective (resp., surjective) if and only if $0\to x\xrightarrow{f}y$ is exact (resp., if $ x\xrightarrow{f}y\to 0$ is exact). This follows from lemmas \ref{lemma-characterize-injective} and \ref{lemma-characterize-zero-map}.
+	In a preabelian category a morphism $f:x\to y$ is injective (resp., surjective) if and only if $0\to x\xrightarrow{f}y$ is exact (resp., if $ x\xrightarrow{f}y\to 0$ is exact). This follows from lemmas \ref{lemma-characterize-injective} and \ref{lemma-characterize-zero-map}. If the category in question is also abelian, then, since on that case all monos and epis will be normal (and thus regular), by Lemma \ref{lemma-characterize-iso} it follows that $f$ is an isomorphism if and only if $0\to x\xrightarrow{f}y\to 0$ is exact.
 \end{remark}
 
 \noindent

--- a/homology.tex
+++ b/homology.tex
@@ -807,7 +807,7 @@ x\ar[r]^f\ar[dr]&y\ar[r]^g&z\\
 &\Im f=\Ker g\ar[u]&&
 }
 $$
-and so, it follows that $gf=0$ since the composite $\Ker g\to y\xrightarrow{g}z$ is zero. Thus, any exact sequence of morphisms in a preabelian category must be a complex.
+and so, it follows that $gf=0$ since the composite $\Ker g\to y\xrightarrow{g}z$ is zero. Thus, any exact sequence of morphisms in an additive category must be a complex.
 
 \begin{lemma}\label{lemma-exact-self-dual}
 	Exactness is a self-dual property: if $x\xrightarrow{f}y\xrightarrow{g}y$ is a sequence on some additive category $\mathcal{A}$, then it is exact if and only the dual sequence on $\mathcal{A}^\mathrm{op}$ is exact. Specifically, $\operatorname{im}f$ and $\ker g$ exist and they are equal if and only if $\operatorname{coker}f$ and $\operatorname{coim}g$ exist and they are equal.
@@ -842,29 +842,29 @@ In an abelian category, using the previous facts, we can also characterize short
 	\begin{slogan}
 		In a complex from an abelian category, the image of a morphism is a subobject of the kernel of the next morphism.
 	\end{slogan}
-	Let $x\xrightarrow{f}y\xrightarrow{g}z$ be a sequence in an abelian category. The sequence is a complex if and only if there exists a morphism $i':\Im f\to\ker g$ such that the diagram
+	Let $x\xrightarrow{f}y\xrightarrow{g}z$ be a sequence in a preabelian category. Then the sequence is a complex if and only if there exists a morphism $i':\Im f\to\ker g$ such that the diagram
 	$$
 	\xymatrix{
 	x\ar[r]^f\ar[d]&y\\
 	\Im f\ar[r]^{i'}&\Ker g\ar[u]	
 	}
 	$$
-	is commutative, where $x\to\Im f$ is the canonical morphism. Moreover, such a morphism $i'$ is unique and injective, and we have that $x\xrightarrow{f}y\xrightarrow{g}z$ is exact if and only if $i'$ is an isomorphism.
+	is commutative, where $x\to\Im f$ is the canonical morphism. Moreover, if such an $i'$ exists, then it is unique and injective, and we have that $x\xrightarrow{f}y\xrightarrow{g}z$ is exact if and only if $i'$ is an isomorphism.
 \end{lemma}
 
 \begin{proof}
 	($\Leftarrow$) If there exists such a factorization of $f$, then $gf$ equals the composite $x\to\Im f\to\Ker g\to y\xrightarrow{g}z$. But the composite $\Ker g\to y\xrightarrow{g}z$ is zero.
 	
-	($\Rightarrow$) Suppose the sequence is a complex.
+	($\Rightarrow$) Suppose the sequence is a complex. Then $g$ factors through $\Coker f$ as $g=g'p$.
 	$$
 	\xymatrix{
-	x\ar[r]^f\ar[d]_{f'}&y\ar[r]^g&z\\
-	\Im f\ar[ru]^i\ar@{-->}[r]_{i'}&\Ker g\ar[u]_j
+	x\ar[r]^f\ar[d]_{f'}&y\ar[r]^g\ar[dr]^p&z\\
+	\Im f\ar[ru]^i\ar@{-->}[r]_{i'}&\Ker g\ar[u]_j&\Coker f\ar[u]_{g'}
 	}
 	$$
-	Then we have $0=gf=gif'$. Since $f'$ is epic (Lemma \ref{lemma-all-epis-normal-coim-map-monic}), we deduce $0=gi$. Therefore $i$ factors as $i=ji'$. Since $i$ is monic (it is a normal monomorphism), by Lemma \ref{lemma-new-mono-epi-from-old} we deduce that $i'$ is also monic.
+	We also have $gi=g'pi=g'0=0$. Therefore $i$ factors uniquely as $i=ji'$. Since $i$ is monic (it is a normal monomorphism), by Lemma \ref{lemma-new-mono-epi-from-old} we deduce that $i'$ is also monic.
 	
-	Uniqueness of $i'$ follows from the fact that $f'$ is epic and $j$ is monic, and we've proven that $i'$ must be a monomorphism, and thus injective.
+	Uniqueness of $i'$ is provided by the universal property of $\ker g$, using the fact that $if'=f$. We've also proven that $i'$ must be a monomorphism, and thus injective.
 	
 	On the other hand, if $x\xrightarrow{f}y\xrightarrow{g}z$ is exact, $\Im f=\Ker g$, then $i'$ must be the identity. And if $i'$ is an isomorphism, then by the factorization $i=ji'$, we have that $\Im f$ and $\Ker g$ are isomorphic as objects over $y$, so $\Im f=\Ker g$.
 \end{proof}

--- a/homology.tex
+++ b/homology.tex
@@ -1770,7 +1770,7 @@ $$
 0 \to A \to A \oplus B \to B \to 0
 $$
 see for example Lemma \ref{lemma-additive-cat-biproduct-kernel}.
-We want to apply the five lemma (Lemma \ref{lemma-five-lemma}) to the diagram
+We want to apply the snake lemma (Lemma \ref{lemma-snake}) to the diagram
 $$
 \xymatrix{
 0 \ar[r] &
@@ -1781,21 +1781,21 @@ F(B) \ar[d] \ar[r] &
 0 \ar[r] &
 F(A) \ar[r] &
 F(A \oplus B) \ar[r]_{Fq} &
-F(B)\ar[r]&0
+F(B)
 }
 $$
 to conclude that $Fi\amalg Fj$ is an
 isomorphism, so we verify the hypotheses.
-We know the top row of the diagram is exact, but also is the bottom row:
-On the one hand, by the assumption we deduce exactness of the bottom row at its first two non-zero terms.
-On the other hand, the bottom row is exact at $F(B)$ too,
-since $q:A\oplus B\to B$ has a retraction $j:B\to A\oplus B$,
-and functors preserve split epimorphisms (see also Remark \ref{remark-characterize-injective-exact-sequence}).
-Moreover, the diagram is commutative on the left square.
+We know the rows are exact.
+On the other hand, the diagram is commutative on the left square.
 To see that the right square also commutes,
 $Fq\circ(Fi\amalg Fj)=Fqi\amalg Fqj=F0\amalg F1_B=0\amalg 1_{FB}$
 (where $F$ preserves the zero map for we know it preserves the zero object).
-Hence $Fi\amalg Fj$ is an isomorphism and,
+Hence, by the snake lemma,
+we deduce that $Fi\amalg Fj$ is injective and surjective and,
+thus, an isomorphism
+(abelian categories are balanced,
+see comments after proof of Lemma \ref{lemma-characterize-abelian-categories}). Therefore,
 by Lemma \ref{lemma-additive-functor}, $F$ is additive.
 Thus, for the rest of the proof we may assume $F$ is additive.
 

--- a/schemes.tex
+++ b/schemes.tex
@@ -187,8 +187,66 @@ Suppose $A$, $B$ are local rings. Any isomorphism of rings
 $A \to B$ is a local ring homomorphism.
 \end{proof}
 
+Let $(f,f^\sharp):(X,\mathcal{O}_X)\to(Y,\mathcal{O}_Y)$
+be a morphism of locally ringed spaces,
+and let $U\subset X$ be open.
+The {\it restriction} of $(f,f^\sharp)$ to $U$
+is the morphism of locally ringed spaces
+$$
+(f,f^\sharp)|_U
+=(f|_U,f^\sharp|_U):
+(U,\mathcal{O}_U)\to(Y,\mathcal{O}_Y),
+$$
+where $\mathcal{O}_U=\mathcal{O}_X|_U$,
+and where we have
+$f^{-1}\mathcal{O}_Y|_U=(f|_U)^{-1}\mathcal{O}_Y$
+thanks to Lemma \ref{lemma-pullback-commutes-restriction}.
+\begin{lemma}
+	\label{lemma-glue-morphisms-locally-ringed-space}
+	Let $(X,\mathcal{O}_X)$ be a locally ringed space,
+	let $X=\bigcup_{i\in I}U_i$ be an open cover of $X$,
+	and let
+	$(f_i,f_i^\sharp):
+	(U_i,\mathcal{O}_{U_i})\to (Y,\mathcal{O}_Y)$
+	be morphisms of locally ringed spaces,
+	where $\mathcal{O}_{U_i}=\mathcal{O}_X|_{U_i}$.
+	Suppose that
+	$(f_i,f_i^\sharp)|_{U_i\cap U_j}
+	=(f_j,f_j^\sharp)|_{U_i\cap U_j}$ for all $i,j\in I$.
+	Then there exists a unique morphism of locally ringed spaces
+	$(f,f^\sharp):(X,\mathcal{O}_X)\to(Y,\mathcal{O}_Y)$
+	such that $(f,f^\sharp)|_{U_i}=(f_i,f_i^\sharp)$
+	for all $i\in I$.
+\end{lemma}
+\begin{proof}
+	This is a consequence of the first mapping property given in Lemma
+	\ref{lemma-glue}
+	(see also the comment after the proof of the Lemma).
+\end{proof}
 
-
+\noindent
+An archetypal example of a sheaf is the sheaf of continuous functions
+on a topological space: given any topological spaces $X,Y$,
+we have that the assignment
+$$
+U\mapsto\operatorname{Mor}(U,Y),
+$$
+where $U\subset X$ is open, gives a sheaf,
+along with the restriction maps.
+It turns out that this is also a sheaf
+in the case of locally ringed spaces.
+\begin{lemma}
+	Let $X,Y$ be locally ringed spaces. Then, the assignment
+	$$
+	U\mapsto\operatorname{Mor}(U,Y),
+	$$
+	along with the restriction maps, is a sheaf.
+	Where $U\subset X$ is open.
+\end{lemma}
+\begin{proof}
+	Lemma \ref{lemma-glue-morphisms-locally-ringed-space} asserts
+	exactly the sheaf property.
+\end{proof}
 
 
 
@@ -2323,7 +2381,7 @@ is a morphism of schemes. Let $x \in X$ be the image of the closed point
 $\mathfrak m \in \Spec(R)$. Then we obtain a local homomorphism
 of local rings
 $$
-f^\sharp :
+f^\sharp_\mathfrak{m} :
 \mathcal{O}_{X, x}
 \longrightarrow
 \mathcal{O}_{\Spec(R), \mathfrak m} = R.
@@ -2558,13 +2616,19 @@ $\varphi_i : X_i \to U_i$ of locally ringed spaces such that
 \item $\varphi_{ij} =
 \varphi_j^{-1}|_{U_i \cap U_j} \circ \varphi_i|_{U_{ij}}$.
 \end{enumerate}
-The locally ringed space $X$ is characterized by the following
-mapping properties: Given a locally ringed space $Y$ we have
+We call a triple
+$(X,\{U_i\},\{\varphi_i\})$
+satisfying properties (1), (2) and (3),
+\emph{a glueing} or a \emph{glued space} for the given glueing data.
+For any glueing $(X,\{U_i\},\{\varphi_i\})$,
+the space $X$ will also satisfy the following
+mapping properties:
+Given a locally ringed space $Y$, there are bijections
 \begin{eqnarray*}
-\Mor(X, Y) & = & \{ (f_i)_{i\in I} \mid
+\Mor(X, Y) & \xrightarrow{\sim} & \{ (f_i)_{i\in I} \mid
 f_i : X_i \to Y, \ f_j \circ \varphi_{ij} = f_i|_{U_{ij}}\} \\
 f & \mapsto & (f|_{U_i} \circ \varphi_i)_{i \in I} \\
-\Mor(Y, X) & = &
+\Mor(Y, X) & \xrightarrow{\sim} &
 \left\{
 \begin{matrix}
 \text{open covering }Y = \bigcup\nolimits_{i \in I} V_i\text{ and }
@@ -2578,6 +2642,25 @@ g_j|_{V_i \cap V_j} = \varphi_{ij} \circ g_i|_{V_i \cap V_j}
 g & \mapsto &
 V_i = g^{-1}(U_i), \ g_i = \varphi_i^{-1} \circ g|_{V_i}
 \end{eqnarray*}
+The glued space $(X,\{U_i\},\{\varphi_i\})$
+is essentially unique in the following sense:
+if $X'$ is another locally ringed space,
+$U_i'\subset X'$ are open subspaces, and
+$\varphi_i':X_i\to U_i'$ are isomorphisms that satisfy
+the analogous properties to (1), (2) and (3),
+(i.e., $(X',\{U_i'\},\{\varphi_i'\})$
+is another glueing for the same glueing data),
+then there exists a unique isomorphism $f:X\to X'$
+of locally ringed spaces such that $f(U_i)=U_i'$ and for which the diagram
+$$
+\xymatrix@R=4pt@C=24pt{
+	&U_i\ar[dd]^f\\
+	X_i\ar[ru]^{\varphi_i}
+	\ar[dr]_{\varphi_i'}\\
+	&U_i'\\
+}
+$$
+commutes, for all $i\in I$.
 \end{lemma}
 
 \begin{proof}
@@ -2644,8 +2727,122 @@ to the stalks of $\mathcal{O}_i$ at corresponding
 points.
 
 \medskip\noindent
-The proof of the mapping properties is omitted.
+We will now prove the first mapping property.
+The proof of the second one will be ommited.
+To prove the mapping properties,
+we forget the particular construction we just have seen
+and only use the properties (1), (2) and (3).
+
+We first show the map is well-defined:
+let $f:X\to Y$ be a morphism of locally ringed spaces,
+and denote $f_i=f|_{U_i}\circ\varphi_i$.
+Then we have
+\begin{align*}
+	f_j\circ\varphi_{ij}
+	&=f|_{U_j}\circ\varphi_j\circ\varphi_{ij}\\
+	&=f|_{U_j}\circ\varphi_i|_{U_{ij}}
+	&\text{by property (3),}\\
+	&=f_i|_{U_{ij}}.
+\end{align*}
+The map is injective:
+if $f,g:X\to Y$ are maps of locally ringed spaces such that
+$f|_{U_i}\circ\varphi_i=g|_{U_i}\circ\varphi_i$,
+then $f|_{U_i}=g|_{U_i}$.
+This implies equality on underlying functions of sets
+and also $f^\sharp=g^\sharp$ by Lemma \ref{lemma-glue-maps}.
+Therefore, $f=g$.
+
+\medskip\noindent
+The map is also surjective:
+For $i\in I$, let $f_i:X_i\to Y$ be maps such that
+$f_j\circ\varphi_{ij}=f_i|_{U_{ij}}$
+for all $i,j\in I$.
+Define the map of locally ringed spaces $g_i:U_i\to Y$
+by $g_i=f_i\circ\varphi_i^{-1}$. Then
+\begin{align*}
+	g_j|_{U_i\cap U_j}
+	&=f_j\circ\varphi_j^{-1}|_{U_i\cap U_j}\\
+	&=f_j\circ\varphi_{ij}\circ\varphi_i^{-1}|_{U_i\cap U_j}
+	&\text{by property (3),}\\
+	&=f_i\circ\varphi_i^{-1}|_{U_i\cap U_j}\\
+	&=g_i|_{U_i\cap U_j}.
+\end{align*}
+Thus, the $g_i$'s gives a well-defined map
+$g:X\to Y$ on underlying sets,
+which is continuous since $g|_{U_i}=g_i$ is continuous.
+Note that the maps $g_i^\sharp$ are of the form
+$g_i^{-1}\mathcal{O}_Y\to\mathcal{O}_{U_i}
+=\mathcal{O}_X|_{U_i}$,
+where
+$g_i^{-1}\mathcal{O}_Y
+=(g|_{U_i})^{-1}\mathcal{O}_Y
+=(g^{-1}\mathcal{O}_Y)|_{U_i}$
+(see Lemma \ref{lemma-pullback-commutes-restriction}).
+Thus, by Lemma \ref{lemma-glue-maps}, we get a map
+$g^\sharp:g^{-1}\mathcal{O}_Y\to\mathcal{O}_X$
+such that $g^\sharp|_{U_i}=g_i^\sharp$.
+
+And we have $g|_{U_i}\circ\varphi_i=f_i$ as morphisms
+of locally ringed spaces.
+
+\medskip\noindent
+Finally, we prove the essential uniqueness of $X$.
+For that, we'll use the mapping property we have just proved.
+Suppose $(X',\{U_i'\},\{\varphi_i'\})$ is another glueing
+for the same glueing data.
+Uniqueness of the isomorphism $f:X\to X'$ follows
+from the mapping property of $X$: if such a map were to exist,
+it would satisfy $f|_{U_{i}}\circ\varphi_i=\iota'_i\circ\varphi_i'$,
+where $\iota_i':U_i'\to X'$ is the inclusion.
+For existence, we define $f_i:X_i\to X'$ to be
+the morphism of locally ringed spaces
+$f_i=\iota_i'\circ\varphi_i'$.
+On that case,
+\begin{align*}
+	f_j\circ\varphi_{ij}
+	&=\iota_j'\circ
+	\varphi_j'\circ
+	(\varphi_j')^{-1}|_{U_i'\cap U_j'}\circ
+	\varphi_i'|_{U_{ij}}\\
+	&=\iota_j'\circ\varphi_i'|_{U_{ij}}\\
+	&=f_i|_{U_{ij}},
+	&\text{since }\iota_i'|_{U_i'\cap U_j'}=\iota_j'|_{U_i'\cap U_j'}.
+\end{align*}
+By the mapping property of $X$,
+we get a map $f:X\to X'$ such that
+$f|_{U_i}\circ\varphi_i=f_i$.
+From this equation it follows that $f(U_i)=U_i'$.
+
+Symmetrically, we use the mapping property of $X'$
+to construct a map $g:X'\to X$.
+Thus, defining $g_i:X_i\to X$ to be $g_i=\iota_i\circ\varphi_i$,
+where $\iota_i:U_i\to X$ is the inclusion,
+we get a map $g:X'\to X$
+such that $g|_{U_i'}\circ\varphi_i'=g_i$.
+
+We have
+\begin{align*}
+	(g\circ f)|_{U_i}\circ\varphi_i
+	&=g\circ (f|_{U_i}\circ\varphi_i)\\
+	&=g\circ f_i\\
+	&=g\circ\iota_i'\circ\varphi_i'\\
+	&=g|_{U_i'}\circ\varphi_{i}'\\
+	&=g_i\circ(\varphi_i')^{-1}\circ\varphi_i'\\
+	&=\iota_i\circ\varphi_i\\
+	&=\operatorname{id}_X|_{U_i}\circ\varphi_i.
+\end{align*}
+By the mapping property of $X$, we conclude that
+$g\circ f=\operatorname{id}_X$.
+Symmetrically, we have $f\circ g=\operatorname{id}_{X'}$.
 \end{proof}
+In particular, from the lemma it follows given
+any locally ringed space $X$ and any open cover
+$X=\bigcup_{i\in I}U_i$,
+then $X$ is {\it the glueing} of its own open cover.
+Here, the glueing data is $X_i=U_i$, $U_{ij}=U_i\cap U_j$ and
+$\varphi_{ij}=\operatorname{id}_{U_{ij}}$,
+whereas the glued space is
+$(X,\{U_i\},\{\varphi_i=\operatorname{id}_{U_i}\})$.
 
 \begin{lemma}
 \label{lemma-glue-schemes}

--- a/schemes.tex
+++ b/schemes.tex
@@ -225,8 +225,11 @@ thanks to Lemma \ref{lemma-pullback-commutes-restriction}.
 \end{proof}
 
 \noindent
-An archetypal example of a sheaf is the sheaf of continuous functions
-on a topological space: given any topological spaces $X,Y$,
+An archetypal example of a sheaf is the sheaf of continuous
+(resp., differentiable) functions between two topological spaces
+(resp., between two $\mathcal{C}^\infty$-manifolds):
+given any topological spaces
+(resp., $\mathcal{C}^\infty$-manifolds) $X,Y$,
 we have that the assignment
 $$
 U\mapsto\operatorname{Mor}(U,Y),

--- a/sheaves.tex
+++ b/sheaves.tex
@@ -429,7 +429,35 @@ is denoted $\textit{PMod}(\mathcal{O})$.
 \end{definition}
 
 \noindent
-Suppose that $\mathcal{O}_1 \to \mathcal{O}_2$ is a
+Let $\mathcal{O}$ be a presheaf of rings on $X$
+and let $\mathcal{F}$ and $\mathcal{G}$ be presheaves of $\mathcal{O}$-modules.
+The tensor product presheaf of $\mathcal{F}$ with $\mathcal{G}$
+is defined by the rule
+$$
+\left(\mathcal{F} \otimes_{p, \mathcal{O}} \mathcal{G}\right)(U)
+=
+\mathcal{F}(U) \otimes_{\mathcal{O}(U)} \mathcal{G}(U).
+$$
+The index $p$ stands for ``presheaf'' and not ``point''.
+If $V\subset U\subset X$ are open sets, then the restriction 
+$\mathcal{F}(U)\otimes_{\mathcal{O}(U)}\mathcal{G}(U)
+\to\mathcal{F}(V)\otimes_{\mathcal{O}(V)}\mathcal{G}(V)$
+is induced by the universal property of 
+$\mathcal{F}(U)\times\mathcal{G}(U)
+\to\mathcal{F}(U)\otimes_{\mathcal{O}(U)}\mathcal{G}(U)$,
+$$
+\xymatrix{
+	\mathcal{F}(U)\times\mathcal{G}(U)\ar[r]\ar[d]
+	&\mathcal{F}(U)\otimes_{\mathcal{O}(U)}\mathcal{G}(U)\ar@{-->}[d]
+	&s\otimes t\ar[d]\ar@{|->}[d]\\
+	\mathcal{F}(V)\times\mathcal{G}(V)\ar[r]
+	&\mathcal{F}(V)\otimes_{\mathcal{O}(V)}\mathcal{G}(V)
+	&s|_V\otimes t|_V
+}
+$$
+
+\noindent
+Suppose now that $\mathcal{O}_1 \to \mathcal{O}_2$ is a
 morphism of presheaves of rings on $X$. In this case,
 if $\mathcal{F}$ is a presheaf of $\mathcal{O}_2$-modules
 then we can think of $\mathcal{F}$ as a presheaf of
@@ -448,40 +476,33 @@ restriction functor
 $$
 \textit{PMod}(\mathcal{O}_2)
 \longrightarrow
-\textit{PMod}(\mathcal{O}_1)
+\textit{PMod}(\mathcal{O}_1).
 $$
 
 \medskip\noindent
 On the other hand, given a presheaf of $\mathcal{O}_1$-modules
 $\mathcal{G}$
-we can construct a presheaf of $\mathcal{O}_2$-modules
-$\mathcal{O}_2 \otimes_{p, \mathcal{O}_1} \mathcal{G}$
-by the rule
-$$
-\left(\mathcal{O}_2 \otimes_{p, \mathcal{O}_1} \mathcal{G}\right)(U)
-=
-\mathcal{O}_2(U) \otimes_{\mathcal{O}_1(U)} \mathcal{G}(U)
-$$
-The index $p$ stands for ``presheaf'' and not ``point''.
-This presheaf is called the tensor product presheaf. We obtain
+we can construct the presheaf of $\mathcal{O}_2$-modules
+$\mathcal{O}_2 \otimes_{p, \mathcal{O}_1} \mathcal{G}$.
+We obtain
 the {\it change of rings} functor
 $$
 \textit{PMod}(\mathcal{O}_1)
 \longrightarrow
-\textit{PMod}(\mathcal{O}_2)
+\textit{PMod}(\mathcal{O}_2).
 $$
 
 \begin{lemma}
 \label{lemma-adjointness-tensor-restrict-presheaves}
 With $X$, $\mathcal{O}_1$, $\mathcal{O}_2$, $\mathcal{F}$ and
-$\mathcal{G}$ as above there exists a canonical bijection
+$\mathcal{G}$ as above, there exists a canonical bijection
 $$
 \Hom_{\mathcal{O}_1}(\mathcal{G}, \mathcal{F}_{\mathcal{O}_1})
 =
 \Hom_{\mathcal{O}_2}(
 \mathcal{O}_2 \otimes_{p, \mathcal{O}_1} \mathcal{G},
 \mathcal{F}
-)
+).
 $$
 In other words, the restriction and change of rings functors
 are adjoint to each other.
@@ -1153,15 +1174,23 @@ Omitted.
 
 \begin{lemma}
 \label{lemma-stalk-tensor-presheaf-modules}
-Let $X$ be a topological space.
-Let $\mathcal{O} \to \mathcal{O}'$ be a morphism of
-presheaves of rings on $X$.
-Let $\mathcal{F}$ be a presheaf of $\mathcal{O}$-modules.
-Let $x \in X$. We have
+Let $X$ be a topological space, let $\mathcal{O}$ be a presheaf of
+rings over $X$,
+let $\mathcal{F}$ and $\mathcal{G}$ be
+presheaves of $\mathcal{O}$-modules, and let $x\in X$.
+We have
+$$
+\mathcal{F}_x \otimes_{\mathcal{O}_x} \mathcal{G}_x
+=
+(\mathcal{F} \otimes_{p, \mathcal{O}} \mathcal{G})_x.
+$$
+
+In particular, if $\mathcal{O} \to \mathcal{O}'$ is a morphism of
+presheaves of rings on $X$, then
 $$
 \mathcal{F}_x \otimes_{\mathcal{O}_x} \mathcal{O}'_x
 =
-(\mathcal{F} \otimes_{p, \mathcal{O}} \mathcal{O}')_x
+(\mathcal{F} \otimes_{p, \mathcal{O}} \mathcal{O}')_x.
 $$
 as $\mathcal{O}'_x$-modules.
 \end{lemma}
@@ -1647,7 +1676,34 @@ the canonical map $\mathcal{F} \to \mathcal{F}^\#$ is injective.
 This is clear from the construction of $\mathcal{F}^\#$ in this
 section.
 \end{proof}
-
+\begin{lemma}
+	\label{lemma-sheafification-commutes-restriction}
+	\begin{slogan}
+		Sheafification commutes with restriction to open sets.
+	\end{slogan}
+	Let $X$ be a space, let $U\subset X$ be open, and let $\mathcal{F}$ be a presheaf on $X$. Then $\mathcal{F}|_U^\#=\mathcal{F}^\#|_U$.
+\end{lemma}
+\begin{proof}
+	Since $\mathcal{F}^\#|_U$ is a sheaf,
+	by the universal property of the sheafification,
+	the restriction to $U$ of the canonical map
+	$\mathcal{F}\to\mathcal{F}^\#$
+	factors through $\mathcal{F}|_U^\#$,
+	$$
+	\xymatrix{
+	\mathcal{F}|_U\ar[r]\ar[d]&\mathcal{F}^\#|_U\\
+	\mathcal{F}|_U^\#\ar@{-->}[ru]
+	}
+	$$
+	Since ``taking induced maps on stalks''
+	is a functorial operation and due to the fact
+	that the top and left maps of the diagram
+	induce isomorphisms on stalks,
+	we deduce that the induced maps on stalks by
+	$\mathcal{F}|_U^\#\to\mathcal{F}^\#|_U$ are also isomorphisms.
+	It follows that this map is an isomorphism,
+	by Lemma \ref{lemma-points-exactness}.
+\end{proof}
 
 
 \section{Sheafification of abelian presheaves}
@@ -1853,15 +1909,29 @@ $i : \textit{Mod}(\mathcal{O}^\#) \to \textit{PMod}(\mathcal{O})$
 (combining restriction and including sheaves into presheaves)
 and the sheafification functor of the lemma
 ${}^\# : \textit{PMod}(\mathcal{O}) \to \textit{Mod}(\mathcal{O}^\#)$
-are adjoint. In a formula
+are adjoint. In a formula,
 $$
 \Mor_{\textit{PMod}(\mathcal{O})}(\mathcal{F}, i\mathcal{G})
 =
-\Mor_{\textit{Mod}(\mathcal{O}^\#)}(\mathcal{F}^\#, \mathcal{G})
+\Mor_{\textit{Mod}(\mathcal{O}^\#)}(\mathcal{F}^\#, \mathcal{G}).
 $$
 
 \medskip\noindent
-Let $X$ be a topological space.
+Let $X$ be a topological space,
+and let $\mathcal{O}$ be a sheaf of rings over $X$. 
+In Section \ref{section-presheaves-modules}
+we defined the tensor product of presheaves. However, if $\mathcal{F}$, $\mathcal{G}$ are sheaves of $\mathcal{O}$-modules, the tensor product $\mathcal{F}\otimes_{p,\mathcal{O}}\mathcal{G}$ is in general not a sheaf. Hence we define the
+{\it tensor product sheaf}
+$\mathcal{F} \otimes_{\mathcal{O}} \mathcal{G}$
+by the formula
+$$
+\mathcal{F} \otimes_{\mathcal{O}} \mathcal{G}
+=
+(\mathcal{F} \otimes_{p, \mathcal{O}} \mathcal{G})^\#,
+$$
+as the sheafification of our construction for presheaves.
+
+\medskip\noindent
 Let $\mathcal{O}_1 \to \mathcal{O}_2$ be
 a morphism of sheaves of rings on $X$.
 In Section \ref{section-presheaves-modules}
@@ -1882,19 +1952,13 @@ $$
 
 \medskip\noindent
 On the other hand, given a sheaf of $\mathcal{O}_1$-modules
-$\mathcal{G}$ the presheaf of $\mathcal{O}_2$-modules
-$\mathcal{O}_2 \otimes_{p, \mathcal{O}_1} \mathcal{G}$
-is in general not a sheaf. Hence we define the
-{\it tensor product sheaf}
-$\mathcal{O}_2 \otimes_{\mathcal{O}_1} \mathcal{G}$
-by the formula
-$$
-\mathcal{O}_2 \otimes_{\mathcal{O}_1} \mathcal{G}
-=
-(\mathcal{O}_2 \otimes_{p, \mathcal{O}_1} \mathcal{G})^\#
-$$
-as the sheafification of our construction for presheaves.
-We obtain the {\it change of rings} functor
+$\mathcal{G}$, we have the sheaf of $\mathcal{O}_2$-modules 
+$\mathcal{O}_2 \otimes_{\mathcal{O}_1} \mathcal{G}$. The structure map 
+$\mathcal{O}_2
+\times(\mathcal{O}_2 \otimes_{\mathcal{O}_1} \mathcal{G})
+\to\mathcal{O}_2 \otimes_{\mathcal{O}_1} \mathcal{G}$
+is given by Lemma \ref{lemma-sheafification-presheaf-modules}.
+We thus obtain the {\it change of rings} functor
 $$
 \textit{Mod}(\mathcal{O}_1)
 \longrightarrow
@@ -1904,7 +1968,7 @@ $$
 \begin{lemma}
 \label{lemma-adjointness-tensor-restrict}
 With $X$, $\mathcal{O}_1$, $\mathcal{O}_2$, $\mathcal{F}$ and
-$\mathcal{G}$ as above there exists a canonical bijection
+$\mathcal{G}$ as above, there exists a canonical bijection
 $$
 \Hom_{\mathcal{O}_1}(\mathcal{G}, \mathcal{F}_{\mathcal{O}_1})
 =
@@ -1935,17 +1999,32 @@ because $\mathcal{F}$ is a sheaf.
 
 \begin{lemma}
 \label{lemma-stalk-tensor-sheaf-modules}
-Let $X$ be a topological space.
-Let $\mathcal{O} \to \mathcal{O}'$ be a morphism of
-sheaves of rings on $X$.
-Let $\mathcal{F}$ be a sheaf $\mathcal{O}$-modules.
-Let $x \in X$. We have
+Let $X$ be a topological space, let $\mathcal{O}$ be a sheaf of rings over $X$, let $\mathcal{F}$ and $\mathcal{G}$ be a sheaves of $\mathcal{O}$-modules, and let $x\in X$. We have
+$$
+\mathcal{F}_x \otimes_{\mathcal{O}_x} \mathcal{G}_x
+=
+(\mathcal{F} \otimes_{ \mathcal{O}} \mathcal{G})_x.
+$$
+
+In particular, if $\mathcal{O} \to \mathcal{O}'$ is a morphism of
+sheaves of rings on $X$, then
 $$
 \mathcal{F}_x \otimes_{\mathcal{O}_x} \mathcal{O}'_x
 =
-(\mathcal{F} \otimes_\mathcal{O} \mathcal{O}')_x
+(\mathcal{F} \otimes_{ \mathcal{O}} \mathcal{O}')_x.
 $$
 as $\mathcal{O}'_x$-modules.
+%Let $X$ be a topological space.
+%Let $\mathcal{O} \to \mathcal{O}'$ be a morphism of
+%sheaves of rings on $X$.
+%Let $\mathcal{F}$ be a sheaf $\mathcal{O}$-modules.
+%Let $x \in X$. We have
+%$$
+%\mathcal{F}_x \otimes_{\mathcal{O}_x} \mathcal{O}'_x
+%=
+%(\mathcal{F} \otimes_\mathcal{O} \mathcal{O}')_x
+%$$
+%as $\mathcal{O}'_x$-modules.
 \end{lemma}
 
 \begin{proof}
@@ -2208,7 +2287,19 @@ To see this
 use that adjoint functors are unique up to unique isomorphism,
 and Lemma \ref{lemma-pushforward-composition}.
 \end{proof}
-
+\begin{lemma}
+	\label{lemma-pullback-commutes-restriction}
+	\begin{slogan}
+		The pullback sheaf commutes with restriction to open sets.
+	\end{slogan}
+	Let $f:X\to Y$ be a continuous map, let $U\subset X$ and $V\subset Y$ be open sets such that $f(U)\subset V$, let $g:U\to V$ be the restriction of $f$ to $U$, and let $\mathcal{G}$ be a sheaf of sets on $Y$. Then
+	$$
+	f^{-1}\mathcal{G}|_U\cong g^{-1}(\mathcal{G}|_V).
+	$$
+\end{lemma}
+\begin{proof}
+	Since sheafification commutes with restriction to open subsets (see Lemma \ref{lemma-sheafification-commutes-restriction}), it suffices to show that $f_p\mathcal{G}|_U\cong g_p(\mathcal{G}|_V)$ for a presheaf $\mathcal{G}$ of sets on $Y$. This follows from the fact that the index category of the diagram which defines $g_p(\mathcal{G}|_V)(U')$, where $U'\subset U$ is open, is a a cofinal subcategory of the index category from the diagram which defines $f_p\mathcal{G}(U')$. Where by ``cofinal subcategory'' we mean one for which the inclusion is a cofinal functor (see Lemma \ref{lemma-cofinal}).
+\end{proof}
 \begin{definition}
 \label{definition-f-map}
 Let $f : X \to Y$ be a continuous map.


### PR DESCRIPTION
This edit affects:

- categories.tex, section of Monomorphisms and Epimorphisms
- homology.tex, sections of
  - Preadditive and additive categories,
  - Abelian categories, and
  - Additive functors.

Summary of the edit:
 - On categories.tex: I've just added a definition and stated two easy lemmas which are used in the new proofs I wrote in homology.tex.
 - On homology.tex:
   1. I've added more detail to the already existing arguments of some proofs regarding preadditive and abelian categories and additive functors.
   2. I've stated and proven the implicit auxiliary results that were being used along these already existing proofs.
   3. I've defined some concepts which aid to state and prove these auxiliary results, and
   4. I've given more equivalences to already existing definitions (e.g., that of an abelian category, see new line 659) and lemmas (e.g., characterization of surjective and injective morphisms, new line 549). The knowledge of these new equivalences is used in i.

I don't know if any of the things I've either stated, proven or detailed in homology.tex are "too obvious" to be here. Some of them are easy, but I think not obvious, at least if it's somebody's first time working with abelian categories (as it is my case). If any of what I wrote should be done in any other way, I would like to know so next time I can do better :)

In each commit I've written a summary of the relevants edits there.