### PR TITLE
Update more-morphisms.tex

### DIFF
--- a/more-morphisms.tex
+++ b/more-morphisms.tex
@@ -14981,7 +14981,7 @@ On the other hand, suppose that $X_s$ is not geometrically connected.
 Then by
 Varieties, Lemma
 \ref{varieties-lemma-characterize-geometrically-disconnected}
-we see that $X_s \times_{\Spec(\kappa(s)} \Spec(k)$ is
+we see that $X_s \times_{\Spec(\kappa(s))} \Spec(k)$ is
 disconnected for some
 finite separable field extension $k/\kappa(s)$. By
 Lemma \ref{lemma-realize-prescribed-residue-field-extension-etale}


### PR DESCRIPTION
Thanks to Yijin Wang  https://stacks.math.columbia.edu/tag/03GZ#comment-7357

Typo in lemma 37.52.3: In the forth line 'we see that X_s×Spec(κ(s) Spec(k) is disconnected ' should be 'we see that X_s×Spec(κ(s)) Spec(k) is disconnected '