### PR TITLE
Update etale-cohomology.tex

### DIFF
--- a/etale-cohomology.tex
+++ b/etale-cohomology.tex
@@ -4630,7 +4630,7 @@ f^{-1} = f_{small}^{-1} :
 \textit{Ab}(X_\etale)
 $$
 which are left adjoint to $f_* = f_{small, *}$. Thus
-$f^{-1}$ thus characterized by the fact that
+$f^{-1}$ is characterized by the fact that
 $$
 \Hom_{{\Sh(X_\etale)}} (f^{-1}\mathcal{G}, \mathcal{F})
 =


### PR DESCRIPTION
Thanks to Long Liu https://stacks.math.columbia.edu/tag/03PZ#comment-7381


Just a typo: in the sentence 'Thus f−1 thus characterized by the fact ...', the second 'thus' should be 'is'.