### PR TITLE
Slogan added

### DIFF
--- a/homology.tex
+++ b/homology.tex
@@ -2677,6 +2677,10 @@ make sense even in a preadditive category.
 
 \begin{lemma}
 \label{lemma-compose-homotopy}
+\begin{slogan}
+Hom functors of $\operatorname{Ch}(\mathcal{A})
+$ respect the homotopy relation.
+\end{slogan}
 Let $\mathcal{A}$ be an additive category.
 Let $f, g : B_\bullet \to C_\bullet$ be morphisms
 of chain complexes. Suppose given morphisms of chain


### PR DESCRIPTION
Thanks to Elías Guisado  https://stacks.math.columbia.edu/tag/010W#comment-7383

Suggested slogan: Hom functors of $\operatorname{Ch}(\mathcal{A})
$ respect the homotopy relation.