### PR TITLE
Update introduction.tex

### DIFF
--- a/introduction.tex
+++ b/introduction.tex
@@ -87,7 +87,7 @@ Descent, Section \ref{descent-section-descent-universally-injective}.
 Fields, Section \ref{fields-section-introduction}.
 \end{enumerate}
 are from
-\href{https://people.fas.harvard.edu/~amathew/cr.html}{The CRing Project},
+\href{https://math.uchicago.edu/~amathew/cr.html}{The CRing Project},
 courtesy of Akhil Mathew et al.
 \item Alex Perry wrote the material on projective modules,
 Mittag-Leffler modules, including the proof of


### PR DESCRIPTION
Update introduction.tex to reflect the new location of the CRing project, which is now at https://math.uchicago.edu/~amathew/cr.html.