### PR TITLE
New section on the annihilator sheaf

### DIFF
--- a/modules.tex
+++ b/modules.tex
@@ -318,8 +318,222 @@ is not needed, see Lemma \ref{lemma-limits-colimits} above.
 \end{proof}
 
 
+\section{The annihilator of a sheaf of modules}
+Recall the following equivalent definitions of modules:
+if $R$ is a commutative ring, then an $R$-module is an abelian group $M$
+together with a ring action $R\times M\to M$, or what it is the same,
+a ring homomorphism $R\to\operatorname{End}(M)$,
+where $\operatorname{End}(M)=\Hom_{Ab}(M,M)$ is
+the non-commutative ring of endomorphisms of abelian groups in $M$. 
 
+\medskip\noindent
+The previous equivalence has the following sheaf-theoric version:
+As it is stated in Sheaves on Spaces,
+Definition \ref{definition-sheaf-modules},
+if $X$ is a space and $\mathcal{O}$ is a sheaf of rings over $X$,
+then a sheaf of $\mathcal{O}$-modules is an abelian sheaf
+$\mathcal{F}$ together with a map of sheaves
+$$
+\mathcal{O}\times\mathcal{F}\to\mathcal{F}
+$$
+such that for every open $U\subset X$,
+the map $\mathcal{O}(U)\times\mathcal{F}(U)\to\mathcal{F}(U)$
+defines an $\mathcal{O}(U)$-module structure on the abelian group
+$\mathcal{F}(U)$. We call such a map
+$\mathcal{O}\times\mathcal{F}\to\mathcal{F}$ a ``sheaf of rings action.''
+Now denote
+$\mathcal{E}nd(\mathcal{F})
+=\SheafHom_{Ab(X)}(\mathcal{F},\mathcal{F})$
+to the sheaf of endomorphisms of abelian sheaves of $\mathcal{F}$.
+Explicitly, its sections over $U\subset X$ are
+$\mathcal{E}nd(\mathcal{F})(U)
+=\Hom_{Ab(U)}(\mathcal{F}|_U,\mathcal{F}|_U)$.
+This way,
+$\mathcal{E}nd(\mathcal{F})$ is a sheaf of non-commutative rings.
 
+\medskip\noindent
+Thus, if $(X,\mathcal{O})$ is a ringed space and $\mathcal{F}$
+is an abelian sheaf over $X$, an $\mathcal{O}$-module structure on
+$\mathcal{F}$ can be defined equivalently either as a sheaf of rings
+action $\mathcal{O}\times\mathcal{F}\to\mathcal{F}$
+or as morphism of sheaves of rings
+$\mathcal{O}\to\mathcal{E}nd(\mathcal{F})$.
+
+\medskip\noindent
+This observation allows us to define the annihilator sheaf in the following way.
+\begin{definition}
+	Let $(X,\mathcal{O}_X)$ be a ringed space and let $\mathcal{F}$
+	be an $\mathcal{O}_X$-module.
+	The annihilator of $\mathcal{F}$,
+	denoted $\operatorname{Ann}\mathcal{F}$,
+	is the kernel of the structure morphism
+	$$
+	\mathcal{O}_X\to\mathcal{E}nd_{Ab(X)}(\mathcal{F}).
+	$$
+	Therefore, the annihilator sheaf is an
+	ideal sheaf of $\mathcal{O}_{X}$.
+\end{definition}
+Under the risk of ambiguity over the (sheaf of) ring(s) for the
+annihilator, we will write things like
+$\operatorname{Ann}_{\mathcal{O}_X}\mathcal{F}$
+or $\operatorname{Ann}_R M$. With this notation, sections of
+$\operatorname{Ann}_{\mathcal{O}_X}\mathcal{F}$ over $U\subset X$ are
+$(\operatorname{Ann}_{\mathcal{O}_X}\mathcal{F})(U)
+=\operatorname{Ann}_{\mathcal{O}_X(U)}\mathcal{F}(U)$.
+
+\medskip\noindent
+There is an obvious morphism of $\mathcal{O}_X$-modules
+$\mathcal{O}_X\to\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})$
+(actually, this is a morphism between sheaves of non-commutative rings).
+On the other hand, the inclusion
+$\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})
+\to\mathcal{E}nd_{Ab(X)}(\mathcal{F})$ is an injective map,
+and the composite
+$\mathcal{O}_X\to
+\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})\to
+\mathcal{E}nd_{Ab(X)}(\mathcal{F})$
+equals the structure morphism of the $\mathcal{O}_X$-module $\mathcal{F}$.
+Thus, the ideal sheaf $\operatorname{Ann}_{\mathcal{O}_X}\mathcal{F}$
+can be equivalently defined as the kernel of the map
+$\mathcal{O}_X\to
+\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})$.
+
+\medskip\noindent
+For each $x\in X$, there is an inclusion of ideals of $\mathcal{O}_{X,x}$:
+\begin{equation}
+	\label{equation-inclusion-of-annihilator-ideals}
+	(\operatorname{Ann}_{\mathcal{O}_X}\mathcal{F})_x\subset
+	\operatorname{Ann}_{\mathcal{O}_{X,x}}\mathcal{F}_x.
+\end{equation}
+Here is one way of seeing this:
+On the one hand, there is a canonical morphism
+$$
+\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})_x\to
+\operatorname{End}_{\mathcal{O}_{X,x}}(\mathcal{F}_x)
+$$
+(which is rarely an isomorphism).
+On the other hand, the ring morphism
+$\mathcal{O}_{X,x}\to
+\operatorname{End}_{\mathcal{O}_{X,x}}(\mathcal{F}_x)$ equals the composite
+\begin{equation}
+	\label{equation-composite-module-structure-stalk}
+	\mathcal{O}_{X,x}\to
+	\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})_x\to
+	\operatorname{End}_{\mathcal{O}_{X,x}}(\mathcal{F}_x),
+\end{equation}
+where the first map is the induced map on stalks by the map
+$\mathcal{O}_{X}\to
+\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})$.
+Since $(\operatorname{Ann}_{\mathcal{O}_X}\mathcal{F})_x$
+is the kernel of the first map in
+\eqref{equation-composite-module-structure-stalk} and
+$\operatorname{Ann}_{\mathcal{O}_{X,x}}\mathcal{F}_x$ is the kernel of
+the composite \eqref{equation-composite-module-structure-stalk},
+we obtain \eqref{equation-inclusion-of-annihilator-ideals}.
+
+\medskip\noindent
+There is a simple situation in which
+\eqref{equation-inclusion-of-annihilator-ideals} becomes an equality.
+\begin{lemma}
+	Let $(X,\mathcal{O}_X)$ be a ringed space and let
+	$\mathcal{F}$ be a sheaf of $\mathcal{O}_X$-modules.
+	If $\mathcal{F}$ is of finite type, then
+	$(\operatorname{Ann}\mathcal{F})_x
+	=\operatorname{Ann}\mathcal{F}_x$.
+\end{lemma}
+\begin{proof}
+	By the previous explanation,
+	it suffices to see that
+	$\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})_x\to
+	\operatorname{End}_{\mathcal{O}_{X,x}}(\mathcal{F}_x)$ is injective.
+	This is done in Lemma \ref{lemma-stalk-internal-hom}.
+\end{proof}
+
+\noindent
+Recall that if $R$ is a ring, $M$ is an $R$-module and $I\subset R$ is an
+ideal such that $I\subset\operatorname{Ann}M$,
+then $M$ has a natural $R/I$-module structure given by $(r+I)x=rx$,
+for $r\in R$, $x\in M$.
+This result has the following sheaf-theoretic version.
+\begin{lemma}
+	Let $(X,\mathcal{O}_X)$ be a ringed space,
+	let $\mathcal{F}$ be an $\mathcal{O}_X$-module and let
+	$\mathcal{I}\subset\mathcal{O}_X$ be an ideal sheaf.
+	If $\mathcal{I}\subset
+	\operatorname{Ann}_{\mathcal{O}_X}\mathcal{F}$,
+	then $\mathcal{F}$ has a natural
+	$\mathcal{O}_X/\mathcal{I}$-module structure.
+	Moreover, for $x\in X$, we have
+	$\mathcal{I}_x\subset
+	\operatorname{Ann}_{\mathcal{O}_{X,x}}\mathcal{F}_x$
+	and that the induced map on stalks by
+	$(\mathcal{O}_X/\mathcal{I})\times\mathcal{F}\to\mathcal{F}$
+	equals the natural $\mathcal{O}_{X,x}/\mathcal{I}_x$-module structure map
+	$(\mathcal{O}_{X,x}/\mathcal{I}_x)\times\mathcal{F}_x
+	\to\mathcal{F}_x$.
+\end{lemma}
+\begin{proof}
+	Applying the universal property of the cokernel of the inclusion
+	$\mathcal{I}\to\mathcal{O}_X$, we obtain a commutative diagram
+	$$
+	\xymatrix{
+		\mathcal{O}_X\ar[r]\ar[d]&\mathcal{E}nd_{Ab(X)}(\mathcal{F})\\
+		\mathcal{O}_X/\mathcal{I}\ar@{-->}[ur]
+	}
+	$$
+	of morphisms of sheaves of non-commutative rings.
+	The morphism
+	$\mathcal{O}_X/\mathcal{I}\to
+	\mathcal{E}nd_{Ab(X)}(\mathcal{F})$
+	gives then the $\mathcal{O}_X/\mathcal{I}$-module
+	structure on $\mathcal{F}$.
+	
+	\medskip\noindent
+	Since
+	$\mathcal{I}_x\subset
+	(\operatorname{Ann}_{\mathcal{O}_X}\mathcal{F})_x$,
+	by \eqref{equation-inclusion-of-annihilator-ideals} we deduce
+	$\mathcal{I}_x\subset
+	\operatorname{Ann}_{\mathcal{O}_{X,x}}\mathcal{F}_x$.
+	The last assertion comes from the fact that the composite
+	$\mathcal{O}_{X,x}\to
+	\mathcal{E}nd_{Ab(X)}(\mathcal{F})_x\to
+	\operatorname{End}_{Ab}(\mathcal{F}_x)$
+	equals the structure morphism $\mathcal{O}_{X,x}\to
+	\operatorname{End}_{Ab}(\mathcal{F}_x)$
+	of $\mathcal{F}_x$ as an $\mathcal{O}_{X,x}$-module.
+	This way, passing the last diagram to stalks and post-composing it with
+	$\mathcal{E}nd_{Ab(X)}(\mathcal{F})_x\to
+	\operatorname{End}_{Ab}(\mathcal{F}_x)$
+	gives a commutative triangle
+	$$
+	\xymatrix{
+	\mathcal{O}_{X,x}\ar[r]\ar[d]&\operatorname{End}_{Ab}(\mathcal{F}_x)\\
+	\mathcal{O}_{X,x}/\mathcal{I}_x\ar[ur]
+	}
+	$$
+	and the morphism
+	$\mathcal{O}_{X,x}/\mathcal{I}_x\to
+	\operatorname{End}_{Ab}(\mathcal{F}_x)$
+	is uniquely determined.
+\end{proof}
+
+\begin{lemma}
+	Let $(X,\mathcal{O}_X)$ be a ringed space.
+	If $\mathcal{O}_X$ and $\mathcal{F}$ are coherent,
+	then so is $\operatorname{Ann}\mathcal{F}$.
+\end{lemma}
+\begin{proof}
+	The kernel of the morphism of coherent $\mathcal{O}_X$-modules
+	$\mathcal{O}_X\to
+	\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})$
+	(i.e., $\operatorname{Ann}\mathcal{F}$) is coherent by Lemma
+	\ref{lemma-internal-hom-locally-kernel-direct-sum}, where
+	$\mathcal{E}nd_{\mathcal{O}_X}(\mathcal{F})$ is coherent by Lemma
+	\ref{lemma-internal-hom-locally-kernel-direct-sum}
+	(note that every coherent sheaves of modules is finitely presented,
+	Lemma \ref{lemma-coherent-finite-presentation}).
+\end{proof}
 
 \section{Sections of sheaves of modules}
 \label{section-sections}
@@ -3540,7 +3754,19 @@ is exact.
 \end{lemma}
 
 \begin{proof}
-Omitted.
+	The sequences in the hom sheaves from (1) and (2) are exact on sections,
+	meaning that, for $U\subset X$ open, the sequences
+	\begin{gather*}
+		0\to\Hom_{\mathcal{O}_U}(\mathcal{F}|_U,\mathcal{G}|_U)\to
+		\Hom_{\mathcal{O}_U}(\mathcal{F}_1|_U,\mathcal{G}|_U)\to
+		\Hom_{\mathcal{O}_U}(\mathcal{F}_2|_U,\mathcal{G}|_U),\\
+		0\to\Hom_{\mathcal{O}_U}(\mathcal{F}|_U,\mathcal{G}|_U)\to
+		\Hom_{\mathcal{O}_U}(\mathcal{F}|_U,\mathcal{G}_1|_U)\to
+		\Hom_{\mathcal{O}_U}(\mathcal{F}|_U,\mathcal{G}_2|_U),
+	\end{gather*}
+	are exact. Applying now exactness of filtered colimits (Commutative Algebra, Lemma \ref{lemma-directed-colimit-exact}),
+	we obtain that the hom sheaves sequences from (1) and (2) are
+	exact on stalks, and thus, exact.
 \end{proof}
 
 \begin{lemma}
@@ -3566,16 +3792,44 @@ and is proved in exactly the same way.
 \label{lemma-stalk-internal-hom}
 Let $(X, \mathcal{O}_X)$ be a ringed space.
 Let $\mathcal{F}$, $\mathcal{G}$ be $\mathcal{O}_X$-modules.
-If $\mathcal{F}$ is finitely presented then the canonical map
+If $\mathcal{F}$ is of finite type then the canonical map
 $$
 \SheafHom_{\mathcal{O}_X}(\mathcal{F}, \mathcal{G})_x
 \to
 \Hom_{\mathcal{O}_{X, x}}(\mathcal{F}_x, \mathcal{G}_x)
 $$
-is an isomorphism.
+is injective.
+If $\mathcal{F}$ is finitely presented,
+this canonical morphism is an isomorphism.
 \end{lemma}
 
 \begin{proof}
+The map sends the equivalence class
+$\overline{(U,\varphi)}\in
+\SheafHom_{\mathcal{O}_X}(\mathcal{F}, \mathcal{G})_x$,
+where $U\subset X$ is open and
+$\varphi\in\Hom_{\mathcal{O}_U}(\mathcal{F}|_U,\mathcal{G}|_U)$,
+to the the induced map on stalks at $x$,
+$\varphi_x:\mathcal{F}_x\to\mathcal{G}_x$.
+
+\medskip\noindent Suppose $\mathcal{F}$ is of finite type.
+Pick a germ $\overline{(U,\varphi)}$ in the kernel of the map,
+i.e., $\varphi_x=0$.
+Shrinking $U$ if necessary, choose sections
+$s^1,\dots,s^n\in\mathcal{F}(U)$ that induce a surjection
+$\mathcal{O}^{\oplus n}_U\to\mathcal{F}|_U$. Since $\varphi_x(s^i_x)=0$
+and we are dealing with a finite number of sections,
+we can find an open neighborhood 
+$V\subset U$ of $x$ such that $\varphi_V(s^i|_V)=0$
+for all $i=1,\dots,n$. Hence, the composite
+$$
+\mathcal{O}^{\oplus n}_V\to\mathcal{F}|_V
+\xrightarrow{\varphi|_V}\mathcal{G}|_V
+$$
+vanishes. Therefore, $\varphi|_V=0$, i.e., $\overline{(U,\varphi)}=0$.
+	
+\medskip\noindent
+Now assume $\mathcal{F}$ is finitely presented.
 By localizing on $X$ we may assume that $\mathcal{F}$ has a presentation
 $$
 \bigoplus\nolimits_{j = 1, \ldots, m}

--- a/modules.tex
+++ b/modules.tex
@@ -362,6 +362,7 @@ $\mathcal{O}\to\mathcal{E}nd(\mathcal{F})$.
 \medskip\noindent
 This observation allows us to define the annihilator sheaf in the following way.
 \begin{definition}
+	\label{definition-annihilator-sheaf}
 	Let $(X,\mathcal{O}_X)$ be a ringed space and let $\mathcal{F}$
 	be an $\mathcal{O}_X$-module.
 	The annihilator of $\mathcal{F}$,
@@ -435,6 +436,7 @@ we obtain \eqref{equation-inclusion-of-annihilator-ideals}.
 There is a simple situation in which
 \eqref{equation-inclusion-of-annihilator-ideals} becomes an equality.
 \begin{lemma}
+	\label{lemma-finite-type-annihilator-stalk}
 	Let $(X,\mathcal{O}_X)$ be a ringed space and let
 	$\mathcal{F}$ be a sheaf of $\mathcal{O}_X$-modules.
 	If $\mathcal{F}$ is of finite type, then
@@ -456,6 +458,7 @@ then $M$ has a natural $R/I$-module structure given by $(r+I)x=rx$,
 for $r\in R$, $x\in M$.
 This result has the following sheaf-theoretic version.
 \begin{lemma}
+	\label{lemma-induced-quotient-ring-sheaf-module-structure}
 	Let $(X,\mathcal{O}_X)$ be a ringed space,
 	let $\mathcal{F}$ be an $\mathcal{O}_X$-module and let
 	$\mathcal{I}\subset\mathcal{O}_X$ be an ideal sheaf.
@@ -519,6 +522,7 @@ This result has the following sheaf-theoretic version.
 \end{proof}
 
 \begin{lemma}
+	\label{lemma-coherent-annihilator}
 	Let $(X,\mathcal{O}_X)$ be a ringed space.
 	If $\mathcal{O}_X$ and $\mathcal{F}$ are coherent,
 	then so is $\operatorname{Ann}\mathcal{F}$.

--- a/sheaves.tex
+++ b/sheaves.tex
@@ -3275,14 +3275,14 @@ $(\{x\}, \mathcal{O}_{X, x}) \to (X, \mathcal{O}_X)$
 and if $A$ is a $\mathcal{O}_{X, x}$-module, then we think
 of $i_{x, *}A$ as a sheaf of $\mathcal{O}_X$-modules.
 \item We say a sheaf of sets $\mathcal{F}$ is a {\it skyscraper sheaf}
-if there exists an point $x$ of $X$ and a set $A$ such
+if there exists a point $x$ of $X$ and a set $A$ such
 that $\mathcal{F} \cong i_{x, *}A$.
 \item We say a sheaf of abelian groups $\mathcal{F}$ is a
-{\it skyscraper sheaf} if there exists an point $x$ of $X$
+{\it skyscraper sheaf} if there exists a point $x$ of $X$
 and an abelian group $A$ such that $\mathcal{F} \cong i_{x, *}A$
 as sheaves of abelian groups.
 \item We say a sheaf of algebraic structures $\mathcal{F}$ is a
-{\it skyscraper sheaf} if there exists an point $x$ of $X$
+{\it skyscraper sheaf} if there exists a point $x$ of $X$
 and an algebraic structure $A$ such that $\mathcal{F} \cong i_{x, *}A$
 as sheaves of algebraic structures.
 \item If $(X, \mathcal{O}_X)$ is a ringed space and


### PR DESCRIPTION
This edit only affects two files, sheaves.tex and modules.tex.

In sheaves.tex, I only corrected some typos.

In modules.tex, I introduced a new section and added material to the section on internal hom:

In the section on the internal hom, I added a proof for `lemma-internal-hom-exact`, which was previously ommited. I also expanded `lemma-stalk-internal-hom`: it previously asserted that the canonical map
![image](https://user-images.githubusercontent.com/26608543/204264288-35e973f3-a25d-4da1-aab7-0c005824b490.png)
is a bijection if $\mathcal{F}$ is finitely presented. I expanded the statement saying additionally that this map is injective if $\mathcal{F}$ is of finite type, and I wrote the proof of this fact there. The reason I expanded this lemma is because this allows to prove that $(\operatorname{Ann}\mathcal{F})_x=\operatorname{Ann}\mathcal{F}_x$ if $\mathcal{F}$ is of finite type (`lemma-finite-type-annihilator-stalk` on the new section on the annihilator sheaf).

The new section is about the annihilator sheaf of a sheaf of modules. The objective I had on mind when I began writing this was to prove the coherence of the annihilator sheaf whenever the sheaves of rings and of modules are both coherent. This is Proposition 15.9 of Serre's _Faisceaux algébriques cohérents_, which on my edit is `lemma-coherent-annihilator`. On the other hand, I should say that my `definition-annihilator-sheaf` is not the exact same definition from the literature. The following are the ones I am aware of:
1. FAC defines the annihilator sheaf only for coherent sheaves,
2. Görtz-Wedhorn _Algebraic Geometry I_, 2nd Edition, in (7.17) only defines it for $X$ a scheme and $\mathcal{F}$ quasi-coherent of finite type.
3. Liu's _Algebraic Geometry and Arithmetic Curves_, in exercise 1.9 from Sect. 5.1 defines it for $X$ a locally Noetherian scheme and $\mathcal{F}$ coherent.

My definition for the annihilator sheaf is equivalent to Liu's and Görtz-Wedhorn's but for an arbitrary sheaf of modules. Two facts make me think this is the right way of thinking of the annihilator sheaf in general:

- The fact that with this definition the sections are
![image](https://user-images.githubusercontent.com/26608543/204269278-0b3d733b-daec-4bc6-a7a8-ae4da8cc9cd0.png)

- The result I included in the new section `lemma-induced-quotient-ring-sheaf-module-structure`, which directly generalizes the situation in commutative algebra.

I'm open to ideas if you think we should define it in other way or do other thing instead.