### PR TITLE
Fixed a typo in lemma-flat-locus-base-change

### DIFF
--- a/more-morphisms.tex
+++ b/more-morphisms.tex
@@ -4386,7 +4386,7 @@ $$
 be a cartesian diagram of schemes.
 Let $\mathcal{F}$ be a quasi-coherent $\mathcal{O}_X$-module.
 Let $x' \in X'$ with images
-$x = g'(x')$ and $s' = g'(x')$.
+$x = g'(x')$ and $s' = f'(x')$.
 \begin{enumerate}
 \item If $\mathcal{F}$ is flat over $S$ at $x$, then
 $(g')^*\mathcal{F}$ is flat over $S'$ at $x'$.


### PR DESCRIPTION
Fixed a typo in lemma-flat-locus-base-change. The element s' \in S' should be the image f'(x'), not g'(x').