### PR TITLE
Add the extensive criterion to more-morphisms.tex

### DIFF
--- a/more-morphisms.tex
+++ b/more-morphisms.tex
@@ -22772,6 +22772,191 @@ morphism.
 
 
 
+\section{The extensive criterion for closed immersions}
+
+\noindent
+In this section, we give a criterion for a morphism of schemes 
+to be a closed immersion.
+
+\begin{lemma} \label{lemma-affine-extensive-criterion}
+A morphism $f: X \ra Y$ of affine schemes is a closed immersion 
+if and only if for every injective ring map $A \ra B$ and commutative 
+square
+\begin{equation*}
+    \begin{tikzcd}
+        \Spec B \arrow[d] \arrow[r] 
+            & X \arrow[d, "f"] \\
+        \Spec A \arrow[r] \arrow[ur, dashed]
+            & Y,
+    \end{tikzcd}
+\end{equation*}
+there exists a lift $\Spec A \ra X$ making the two triangles commute.
+\end{lemma}
+
+\begin{proof}
+The morphism $f$ is given by a ring map $\phi: R \ra S$, and it is a 
+closed immersion if and only if $\phi$ is surjective.
+
+\medskip \noindent
+First, we assume that $\phi$ is surjective.
+Let $\psi: A \ra B$ be an injective ring map, and suppose we are given 
+a commutative diagram
+\begin{equation*}
+    \begin{tikzcd}
+        R \arrow[r, "\alpha"] \arrow[d, "\phi"] 
+            & A \arrow[d, "\psi"] \\
+        S \arrow[r, "\beta"] \arrow[ur, dashed]
+            & B.
+    \end{tikzcd}
+\end{equation*}
+Then we define a lift $S \ra A$ by $s \mapsto \alpha(r)$, where 
+$r \in R$ is such that $\phi(r) = s$. 
+This is well-defined because $\psi$ is injective and the square commutes.
+It is also unique because $\psi$ is a monomorphism in the category of 
+commutative rings.
+Since taking the ring spectrum defines an anti-equivalence between 
+commutative rings and affine schemes, the desired lifting property for 
+$f$ holds.
+
+\medskip \noindent
+Next, we assume that $\phi$ has unique lifts against all injective ring 
+maps $\psi: A \ra B$.
+Note that $\phi(R)$ is a subring of $S$, so we obtain a commutative 
+square
+\begin{equation*}
+    \begin{tikzcd}
+        R \arrow[r] \arrow[d, "\phi"] 
+            & \phi(R) \arrow[d] \\
+        S \arrow[r, equal] \arrow[ur, dashed]
+            & S.
+    \end{tikzcd}
+\end{equation*}
+in which a unique lift $S \ra \phi(R)$ exists. 
+Hence, the inclusion $\phi(R) \ra S$ must be an isomorphism, which 
+shows that $\phi$ is surjective, and we win.
+\end{proof}
+
+\noindent
+Let $X$ be a scheme and $\aff: X \ra \Spec \mathcal{O}_X(X)$ the 
+canonical map induced by the identity on $\mathcal{O}_X(X)$. 
+
+\begin{lemma} \label{lemma-scheme-affine-if-aff-is-split-mono}
+If $\aff$ is a split monomorphism in $\Sch$, then $X$ is an affine scheme.
+\end{lemma}
+
+\begin{proof}
+Write $S = \Spec \OO_X(X)$.
+Let $s: S \ra X$ be a morphism such that $s \aff = \id_X$. 
+Then
+\begin{equation*}
+    \aff s \aff = \id_{S} \aff
+\end{equation*}
+and since both $\aff s$ and $\id_{S}$ are morphisms of affine schemes, 
+it follows that $\aff s = \id_{S}$ by lemma \ref{lemma-morphism-into-affine}.
+Hence $\aff$ is an isomorphism and $X$ is an affine scheme, 
+as was to be shown.
+\end{proof}
+
+\begin{lemma} \label{lemma-aff-is-injective-on-sheaves}
+The largest quasi-coherent $\OO_{\Spec \OO_X(X)}$-module contained 
+in the kernel of the canonical morphism of sheaves 
+$\phi: \OO_{\Spec \OO_X(X)} \ra \aff_*\OO_X$ is zero.
+If $X$ is quasi-compact, then $\phi$ is injective.
+In particular, if $X$ is quasi-compact, then $\aff$ is a 
+dominant morphism.
+\end{lemma}
+
+\begin{proof}
+Let $M \subset \OO_X(X)$ be the $\OO_X(X)$-module corresponding to 
+the largest quasi-coherent $\OO_{\Spec \OO_X(X)}$-module contained 
+in the kernel of $\phi$.
+By definition,
+\begin{equation*}
+    \phi(\widetilde{M}(D(f))) = \phi(M[\tfrac{1}{f}]) = 0
+\end{equation*}
+for all $f \in \OO_X(X)$.
+In particular, the above equation holds for $f=1$, and since 
+$\phi: \OO_{\Spec \OO_X(X)}(\Spec \OO_X(X)) \ra \aff_*\OO_X(\Spec \OO_X(X))$ 
+is simply the identity on $\OO_X(X)$, it follows that $M = 0$. 
+Note that this is equivalent to the affinification morphism 
+$\aff: X \ra \Spec \OO_X(X)$ being scheme-theoretically surjective.
+
+\medskip \noindent
+If $X$ is quasi-compact, then $\ker \phi$ is quasi-coherent by 
+lemma \ref{lemma-quasi-compact-scheme-theoretic-image}, 
+so $\phi$ is injective.
+In this case, $\aff$ is a dominant morphism.
+\end{proof}
+
+\begin{lemma} \label{lemma-extensive-criterion}
+Let $f: X \ra Y$ be a quasi-compact morphism in $\Sch$.
+Then $f$ is a closed immersion if and only if for every injective 
+ring map $A \ra B$ and commutative square
+\begin{equation*}
+    \begin{tikzcd}
+        \Spec B \arrow[d] \arrow[r] 
+            & X \arrow[d, "f"] \\
+        \Spec A \arrow[r] \arrow[ur, dashed]
+            & Y,
+    \end{tikzcd}
+\end{equation*}
+there exists a lift $\Spec A \ra X$ making the diagram commute.
+\end{lemma}
+
+\begin{proof}
+Let $\aff: X \ra \Spec \mathcal{O}_X(X)$ be the canonical morphism, 
+which is dominant by proposition \ref{lemma-aff-is-injective-on-sheaves}. 
+
+\medskip \noindent
+First, assume that $f$ has the lifting property stated in the lemma.
+Being a closed immersion is a local condition, so $Y$ may be assumed affine.
+In particular, $Y$ is quasi-compact and therefore $X$ is quasi-compact.
+Hence there exists a finite affine cover $\{X_i\}_{i \in I}$ of $X$.
+Then the source of the dominant surjection
+\begin{equation*}
+    \pi: \coprod_{i \in I}X_i \lra X
+\end{equation*}
+is affine.
+Hence $\aff \pi$ is dominant, and corresponds to the injective ring map
+\begin{equation*}
+    \OO_X(X) \lra \prod_{i \in I}\OO_X(X_i).
+\end{equation*}
+By assumption, there exists a unique lift in the diagram
+\begin{equation*}
+    \begin{tikzcd}
+        \coprod_{i \in I}X_i \arrow[r, "\pi"] \arrow[d]
+            & X \arrow[d, "f"] \\
+        \Spec \OO_X(X) \arrow[r, "f'"] \arrow[ur, dashed, "h"]
+            & Y,
+    \end{tikzcd}
+\end{equation*}
+where $f'$ is the morphism of affine schemes corresponding to the 
+ring map $\mathcal{O}_Y(Y) \ra \mathcal{O}_X(X)$.
+It follows that $h \aff \pi = \pi$, and since $\pi$ is an epimorphism 
+in the category of schemes, $h \aff = \id_X$. 
+Hence, $\aff$ is a split monomorphism and $X$ is affine by lemma 
+\ref{lemma-scheme-affine-if-aff-is-split-mono}.
+By lemma \ref{lemma-affine-extensive-criterion}, 
+$f$ is a closed immersion.
+
+Now assume that $f$ is a closed immersion.
+Let $A \ra B$ be an injective ring map and consider a commutative square
+\begin{equation*}
+    \begin{tikzcd}
+        \Spec B \arrow[d] \arrow[r] 
+            & X \arrow[d, "f"] \\
+        \Spec A \arrow[r] \arrow[ur, dashed]
+            & Y.
+    \end{tikzcd}
+\end{equation*}
+Existence of unique lifts can be checked locally on $Y$, so we assume 
+$Y = \Spec R$ to be affine.
+Then $X \cong \Spec R/I$ for some ideal $I \subset R$, and we obtain a 
+unique lift by lemma \ref{lemma-affine-extensive-criterion}.
+\end{proof}
+
+
+
 
 
 \input{chapters}


### PR DESCRIPTION
This change includes a self-contained proof of the extensive criterion for closed immersions in a separate section in the chapter "More on Morphisms". All references are internal to the stacks project.