### PR TITLE
typos in Separated maps

### DIFF
--- a/topology.tex
+++ b/topology.tex
@@ -259,12 +259,12 @@ in $X \times_Y X$.
 \begin{lemma}
 \label{lemma-base-change-separated}
 Let $f : X \to Y$ and $Y' \to Y$ be continuous maps of topological spaces.
-If $f$ is separated, then $f' : Y' \times_Y X \to Z$ is separated.
+If $f$ is separated, then $f' : Y' \times_Y X \to Y'$ is separated.
 \end{lemma}
 
 \begin{proof}
-Follows from characterization (3) of Lemma \ref{lemma-separated}.
-Namely, with $X' = Y' \times_Y X$ the image $\Delta(X')$ of the diagonal
+Follows from characterization (2) of Lemma \ref{lemma-separated}.
+Namely, with $X' = Y' \times_Y X$ the diagonal $\Delta(X')$
 in the fibre product $X' \times_{Y'} X'$ is the inverse image of
 $\Delta(X)$ in $X \times_Y X$.
 \end{proof}


### PR DESCRIPTION
By the way, I formalized the whole section in Lean and none of the results actually requires any continuity. It's now [in mathlib4](https://github.com/leanprover-community/mathlib4/commit/83b113a51376df94dbaa7eb68f11af3dac551628#diff-2e469ea5b4f7f5e4014bc1c16a12d4342f7c740e57caf6f821c4d10d96c4aadd).