### PR TITLE
Update python scripts from v2.x to v3.7+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,10 @@ pdfs: $(FOOS) $(BARS) $(PDFS)
 
 # Automatically generated tex files
 tmp/index.tex: *.tex
-	python2 ./scripts/make_index.py "$(CURDIR)" > tmp/index.tex
+	python ./scripts/make_index.py "$(CURDIR)" > tmp/index.tex
 
 tmp/book.tex: *.tex tmp/index.tex
-	python2 ./scripts/make_book.py "$(CURDIR)" > tmp/book.tex
+	python ./scripts/make_book.py "$(CURDIR)" > tmp/book.tex
 
 # Creating aux files
 index.foo: tmp/index.tex
@@ -160,19 +160,19 @@ book.dvi: tmp/book.tex book.bar
 #
 #
 tags/tmp/book.tex: tmp/book.tex tags/tags
-	python2 ./scripts/tag_up.py "$(CURDIR)" book > tags/tmp/book.tex
+	python ./scripts/tag_up.py "$(CURDIR)" book > tags/tmp/book.tex
 
 tags/tmp/index.tex: tmp/index.tex
 	cp tmp/index.tex tags/tmp/index.tex
 
 tags/tmp/preamble.tex: preamble.tex tags/tags
-	python2 ./scripts/tag_up.py "$(CURDIR)" preamble > tags/tmp/preamble.tex
+	python ./scripts/tag_up.py "$(CURDIR)" preamble > tags/tmp/preamble.tex
 
 tags/tmp/chapters.tex: chapters.tex
 	cp chapters.tex tags/tmp/chapters.tex
 
 tags/tmp/%.tex: %.tex tags/tags
-	python2 ./scripts/tag_up.py "$(CURDIR)" $* > tags/tmp/$*.tex
+	python ./scripts/tag_up.py "$(CURDIR)" $* > tags/tmp/$*.tex
 
 tags/tmp/stacks-project.cls: stacks-project.cls
 	cp stacks-project.cls tags/tmp/stacks-project.cls
@@ -256,4 +256,4 @@ web: tmp/index.tex
 	@echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
 	cp my.bib $(WEBDIR)/my.bib
 	cp tags/tags $(WEBDIR)/tags
-	python2 ./scripts/web_book.py "$(CURDIR)" > $(WEBDIR)/book.tex
+	python ./scripts/web_book.py "$(CURDIR)" > $(WEBDIR)/book.tex

--- a/scripts/add_tags.py
+++ b/scripts/add_tags.py
@@ -6,15 +6,15 @@ tags = get_tags(path)
 
 new_tags = get_new_tags(path, tags)
 
-print "About to write",
-print len(new_tags),
-print "new tags. Here is the list:"
-print
-print_new_tags(new_tags)
-print
+print("About to write",)
+print(len(new_tags),)
+print("new tags. Here is the list:")
+print()
+print_new_tags(new_tags))
+print()
 var = raw_input("Do you want to do this? (no/yes)")
 if var == "yes":
 	write_new_tags(path, new_tags)
-	print "Tags were written."
+	print("Tags were written.")
 else:
-	print "No tags were written."
+	print("No tags were written.")

--- a/scripts/add_tags.py
+++ b/scripts/add_tags.py
@@ -10,7 +10,7 @@ print("About to write",)
 print(len(new_tags),)
 print("new tags. Here is the list:")
 print()
-print_new_tags(new_tags))
+print_new_tags(new_tags)
 print()
 var = raw_input("Do you want to do this? (no/yes)")
 if var == "yes":

--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -2,10 +2,10 @@
 def get_path():
 	from sys import argv
 	if not len(argv) == 2:
-		print
-		print "This script needs exactly one argument"
-		print "namely the path to the stacks project directory"
-		print
+		print()
+		print("This script needs exactly one argument")
+		print("namely the path to the stacks project directory")
+		print()
 		raise Exception('Wrong arguments')
 	path = argv[1]
 	path.rstrip("/")
@@ -37,7 +37,7 @@ def find_defined_terms(def_text):
 def git_version(path):
 	from subprocess import Popen, PIPE, STDOUT
 	cmd = 'git --git-dir=' + path + '.git log --pretty=format:%h -n1'
-	p = Popen(cmd, shell=True, stdout=PIPE).stdout
+	p = Popen(cmd, shell=True, text=True, stdout=PIPE).stdout
 	version = p.read()
 	p.close()
 	return version
@@ -142,7 +142,7 @@ def get_new_tags(path, tags):
 def print_new_tags(new_tags):
 	n = 0
 	while n < len(new_tags):
-		print new_tags[n][0] + "," + new_tags[n][1]
+		print(ew_tags[n][0] + "," + new_tags[n][1])
 		n = n + 1
 	return
 
@@ -205,7 +205,7 @@ def list_text_files(path):
 		line = line.rstrip()
 		line = line.rstrip("\\")
 		lijst = lijst + " " + line
-		line = Makefile_file.next()
+		line = Makefile_file.readline()
 	Makefile_file.close()
 	lijst = lijst + " " + line
 	lijst = lijst.replace("LIJST = ", "")
@@ -315,7 +315,7 @@ def replace_refs(line, name):
 def print_chapters(path):
 	chapters = open(path + "chapters.tex", 'r')
 	for line in chapters:
-		print line,
+		print(line,)
 	chapters.close()
 	return
 
@@ -324,7 +324,7 @@ def print_version(path):
 	from datetime import date
 	now = date.today()
 	version = git_version(path)
-	print "Version " + version + ", compiled on " + now.strftime('%h %d, %Y.')
+	print("Version " + version + ", compiled on " + now.strftime('%h %d, %Y.'))
 
 
 # Print license blurp
@@ -337,7 +337,7 @@ def print_license_blurp(path):
 			inside = 1
 		if inside == 0:
 			continue
-		print line,
+		print(line.rstrip())
 		if line.find('\\end{verbatim}') == 0:
 			inside = 0
 	introduction.close()

--- a/scripts/make_book.py
+++ b/scripts/make_book.py
@@ -18,7 +18,7 @@ def print_preamble(path):
 		if line.find("\\documentclass") == 0:
 			line = line.replace("amsart", "amsbook")
 			line = line.replace("stacks-project", "stacks-project-book")
-		print line,
+		print(line,)
 	preamble.close()
 	return
 
@@ -42,27 +42,27 @@ def print_list_contrib(path):
 		contributors = contributors + ", " + contributor
 	CONTRIBUTORS.close()
 	contributors = contributors + "."
-	print contributors
+	print(contributors)
 
 path = get_path()
 
 print_preamble(path)
 
-print "\\begin{document}"
-print "\\begin{titlepage}"
-print "\\pagestyle{empty}"
-print "\\setcounter{page}{1}"
-print "\\centerline{\\LARGE\\bfseries Stacks Project}"
-print "\\vskip1in"
-print "\\noindent"
-print "\\centerline{"
+print("\\begin{document}")
+print("\\begin{titlepage}")
+print("\\pagestyle{empty}")
+print("\\setcounter{page}{1}")
+print("\\centerline{\\LARGE\\bfseries Stacks Project}")
+print("\\vskip1in")
+print("\\noindent")
+print("\\centerline{")
 print_version(path)
-print "}"
-print "\\vskip1in"
-print "\\noindent"
-print "The following people have contributed to this work:"
+print("}")
+print("\\vskip1in")
+print("\\noindent")
+print("The following people have contributed to this work:")
 print_list_contrib(path)
-print "\\end{titlepage}"
+print("\\end{titlepage}")
 print_license_blurp(path)
 
 lijstje = list_text_files(path)
@@ -73,7 +73,7 @@ parts = get_parts(path)
 ext = ".tex"
 for name in lijstje:
 	if name in parts:
-		print "\\part{" + parts[name][0] + "}"
+		print("\\part{" + parts[name][0] + "}")
 	if name == "index":
 		filename = path + "tmp/index.tex"
 	else:
@@ -81,12 +81,13 @@ for name in lijstje:
 	tex_file = open(filename, 'r')
 	verbatim = 0
 	for line in tex_file:
+		line = line.rstrip()
 		verbatim = verbatim + beginning_of_verbatim(line)
 		if verbatim:
 			if end_of_verbatim(line):
 				verbatim = 0
 			if name != 'introduction':
-				print line,
+				print(line,)
 			continue
 		if line.find("\\input{preamble}") == 0:
 			continue
@@ -109,11 +110,11 @@ for name in lijstje:
 			line = line.replace("\\label{", text)
 		if contains_ref(line):
 			line = replace_refs(line, name)
-		print line,
+		print(line,)
 
 	tex_file.close()
 	print_chapters(path)
 
-print "\\bibliography{my}"
-print "\\bibliographystyle{amsalpha}"
-print "\\end{document}"
+print("\\bibliography{my}")
+print("\\bibliographystyle{amsalpha}")
+print("\\end{document}")

--- a/scripts/make_index.py
+++ b/scripts/make_index.py
@@ -1,26 +1,26 @@
 from functions import *
 
 def print_section_title(title):
-	print
-	print "\\medskip\\noindent"
-	print "{\\bf " + title + "}"
-	print
-	print "\\medskip"
+	print("")
+	print("\\medskip\\noindent")
+	print("{\\bf " + title + "}")
+	print("")
+	print("\\medskip")
 	return
 
 def print_def_terms(label, def_terms):
-	print
-	print "\\noindent"
-	print "In \\ref{" + label + "}: "
+	print("")
+	print("\\noindent")
+	print("In \\ref{" + label + "}: ")
 	n = len(def_terms)
 	m = 0
 	while m < n:
 		if m + 1 < n:
-			print def_terms[m] + ","
+			print(def_terms[m] + ",")
 		else:
-			print def_terms[m]
+			print(def_terms[m])
 		m = m + 1
-	print
+	print("")
 	return
 
 def add_def_terms(terms, label, def_terms):
@@ -78,31 +78,31 @@ for name in lijstje:
 	tex_file.close()
 
 
-print "\\input{preamble}"
-print "\\begin{document}"
-print "\\title{Auto generated index}"
-print "\\maketitle"
-print
-print "\\phantomsection"
-print "\\label{section-phantom}"
-print
-print "\\tableofcontents"
-print
-print "\\frenchspacing"
-print
-print
-print "\\begin{multicols}{2}[\\section{Alphabetized definitions}\\label{section-alphabetized}]"
+print("\\input{preamble}")
+print("\\begin{document}")
+print("\\title{Auto generated index}")
+print("\\maketitle")
+print()
+print("\\phantomsection")
+print("\\label{section-phantom}")
+print()
+print("\\tableofcontents")
+print()
+print("\\frenchspacing")
+print()
+print()
+print("\\begin{multicols}{2}[\\section{Alphabetized definitions}\\label{section-alphabetized}]")
 terms.sort(key=lambda x: x[0].lower())
 n = 0
 while n < len(terms):
-	print "\\noindent"
-	print terms[n][0]
-	print "in \\ref{" + terms[n][1] + "}"
-	print
+	print("\\noindent")
+	print(terms[n][0])
+	print("in \\ref{" + terms[n][1] + "}")
+	print()
 	n = n + 1
-print "\\end{multicols}"
-print
-print "\\begin{multicols}{2}[\\section{Definitions listed per chapter}\\label{section-per-chapter}]"
+print("\\end{multicols}")
+print()
+print("\\begin{multicols}{2}[\\section{Definitions listed per chapter}\\label{section-per-chapter}]")
 n = 0
 m = 0
 for name in lijstje:
@@ -112,7 +112,7 @@ for name in lijstje:
 		print_def_terms(defs[n][1], defs[n][0])
 		n = n + 1
 
-print "\\end{multicols}"
-print
-print "\\input{chapters}"
-print "\\end{document}"
+print("\\end{multicols}")
+print()
+print("\\input{chapters}")
+print("\\end{document}")

--- a/scripts/tag_up.py
+++ b/scripts/tag_up.py
@@ -2,11 +2,11 @@ from functions import *
 
 from sys import argv
 if not len(argv) == 3:
-	print
-	print "This script needs exactly two arguments"
-	print "namely the path to the stacks project"
-	print "and the stem of the tex file"
-	print
+	print()
+	print("This script needs exactly two arguments")
+	print("namely the path to the stacks project")
+	print("and the stem of the tex file")
+	print()
 	raise Exception('Wrong arguments')
 
 path = argv[1]
@@ -31,17 +31,17 @@ def replace_newtheorem(line):
 if name == "preamble":
 	tex_file = open(path + name + ".tex", 'r')
 	for line in tex_file:
-		print replace_newtheorem(line),
+		print(replace_newtheorem(line),)
 
 	version = git_version(path)
 
 	from datetime import date
 	now = date.today()
 
-	print "\\usepackage{marginnote}"
-	print "\\renewcommand*{\\marginfont}{\\normalfont}"
+	print("\\usepackage{marginnote}")
+	print("\\renewcommand*{\\marginfont}{\\normalfont}")
 
-	print "\\date{This is a chapter of the Stacks Project, version " + version + ", compiled on " + now.strftime('%h %d, %Y.}')
+	print("\\date{This is a chapter of the Stacks Project, version " + version + ", compiled on " + now.strftime('%h %d, %Y.}'))
 
 	tex_file.close()
 
@@ -63,13 +63,13 @@ else:
 document = 0
 verbatim = 0
 for line in tex_file:
-	
+
 	# Check for verbatim
 	verbatim = verbatim + beginning_of_verbatim(line)
 	if verbatim:
 		if end_of_verbatim(line):
 			verbatim = 0
-		print line,
+		print(line,)
 		continue
 
 	# Do stuff in preamble or just after \begin{document}
@@ -77,11 +77,11 @@ for line in tex_file:
 		if name == "book":
 			line = replace_newtheorem(line)
 			if line.find("\\begin{document}") == 0:
-				print "\\usepackage{marginnote}"
-				print "\\renewcommand*{\\marginfont}{\\normalfont}"
-		print line,
+				print("\\usepackage{marginnote}")
+				print("\\renewcommand*{\\marginfont}{\\normalfont}")
+		print(line,)
 		if line.find("\\begin{document}") == 0:
-			print "\\newcommand{\\TAG}{ZZZZ}"
+			print("\\newcommand{\\TAG}{ZZZZ}")
 			document = 1
 		continue
 
@@ -92,25 +92,25 @@ for line in tex_file:
 			label = short
 		else:
 			label = name + "-" + short
-		print line,
+		print(line,)
 		# don't put in hypertarget if label does not have a tag
 		if label in label_tags:
-                        print "\\hypertarget{" + label_tags[label] + "}{}"
+                        print("\\hypertarget{" + label_tags[label] + "}{}")
                         # there is a bug in marginnotes that eats subsection titles...
                         if short.find("subsection") >= 0:
-				line = tex_file.next()
-				print line,
-				line = tex_file.next()
-				print line,
-				print "\\reversemarginpar\\marginnote{" + label_tags[label] + "}"
+				line = tex_file.readline()
+				print(line,)
+				line = tex_file.readline()
+				print(line,)
+				print("\\reversemarginpar\\marginnote{" + label_tags[label] + "}")
 			else:
-				print "\\reversemarginpar\\marginnote{" + label_tags[label] + "}"
+				print("\\reversemarginpar\\marginnote{" + label_tags[label] + "}")
 		continue
 
 	# Lines with labeled environments
 	if labeled_env(line):
 		oldline = line
-		line = tex_file.next()
+		line = tex_file.readline()
 		short = find_label(line)
 		if name == "book":
 			label = short
@@ -118,24 +118,24 @@ for line in tex_file:
 			label = name + "-" + short
 		if not label in label_tags:
 			# ZZZZ is used as pointer to nonexistent tags
-			print "\\renewcommand{\\TAG}{ZZZZ}"
-			print oldline,
-			print line,
+			print("\\renewcommand{\\TAG}{ZZZZ}")
+			print(oldline,)
+			print(line,)
 			continue
-		print "\\renewcommand{\\TAG}{" + label_tags[label] + "}"
-		print oldline,
-		print line,
-		print "\\reversemarginpar\\marginnote{" + label_tags[label] + "}\\hypertarget{" + label_tags[label] + "}{}"
+		print("\\renewcommand{\\TAG}{" + label_tags[label] + "}")
+		print(oldline,)
+		print(line,)
+		print("\\reversemarginpar\\marginnote{" + label_tags[label] + "}\\hypertarget{" + label_tags[label] + "}{}")
 		continue
 
 	if line.find("\\begin{reference}") == 0:
-		print "\\normalmarginpar\\marginnote{"
+		print("\\normalmarginpar\\marginnote{")
 		continue
 
 	if line.find("\\end{reference}") == 0:
-		print "}"
+		print("}")
 		continue
 
-	print line,
+	print(line,)
 
 tex_file.close()

--- a/scripts/web_book.py
+++ b/scripts/web_book.py
@@ -13,8 +13,8 @@ def print_preamble(path):
 	next(preamble)
 	next(preamble)
 	next(preamble)
-	print "\\documentclass{book}"
-	print "\\usepackage{amsmath}"
+	print("\\documentclass{book}")
+	print("\\usepackage{amsmath}")
 	for line in preamble:
 		if line.find("%") == 0:
 			continue
@@ -30,7 +30,7 @@ def print_preamble(path):
 			continue
 		if line.find("xr-hyper") >= 0:
 			continue
-		print line,
+		print(line,)
 	preamble.close()
 	return
 
@@ -38,17 +38,17 @@ path = get_path()
 
 print_preamble(path)
 
-print "\\begin{document}"
-print "\\begin{titlepage}"
-print "\\pagestyle{empty}"
-print "\\setcounter{page}{1}"
-print "\\centerline{\\LARGE\\bfseries Stacks Project}"
-print "\\vskip1in"
-print "\\noindent"
-print "\\centerline{"
+print("\\begin{document}")
+print("\\begin{titlepage}")
+print("\\pagestyle{empty}")
+print("\\setcounter{page}{1}")
+print("\\centerline{\\LARGE\\bfseries Stacks Project}")
+print("\\vskip1in")
+print("\\noindent")
+print("\\centerline{")
 print_version(path)
-print "}"
-print "\\end{titlepage}"
+print("}")
+print("\\end{titlepage}")
 print_license_blurp(path)
 
 lijstje = list_text_files(path)
@@ -58,9 +58,9 @@ parts = get_parts(path)
 ext = ".tex"
 for name in lijstje:
 	if name in parts:
-		print "\\part{" + parts[name][0] + "}"
-		print "\\label{" + parts[name][1] + "}"
-	
+		print("\\part{" + parts[name][0] + "}")
+		print("\\label{" + parts[name][1] + "}")
+
 	filename = path + name + ext
 	tex_file = open(filename, 'r')
 	verbatim = 0
@@ -70,7 +70,7 @@ for name in lijstje:
 			if end_of_verbatim(line):
 				verbatim = 0
 			if name != 'introduction':
-				print line,
+				print(line,)
 			continue
 		if line.find("\\input{preamble}") == 0:
 			continue
@@ -93,10 +93,10 @@ for name in lijstje:
 			line = line.replace("\\label{", text)
 		if contains_ref(line):
 			line = replace_refs(line, name)
-		print line,
+		print(line,)
 
 	tex_file.close()
 
-print "\\bibliography{my}"
-print "\\bibliographystyle{amsalpha}"
-print "\\end{document}"
+print("\\bibliography{my}")
+print("\\bibliographystyle{amsalpha}")
+print("\\end{document}")


### PR DESCRIPTION
In order to retire the use of python versions which no-longer have security patches, I have:

- Changed all instances of `python2` to `python`.
- Updated `print` statements to be compatible with v3.7+
- Changed calls to `next` on FileIO streams (which no longer support `next`) to `readline`
- Added `rstrip()` to lines read from an FileIO stream so that double newlines were not introduced
  - these extra newlines were confusing the use of "block-mathematic-quotes" ('$$')
- Added an explicit `text=True` in the POpen call in `git_version`

The above changes were "tested" by building a local copy of the Stacks-project using `make all`