### PR TITLE
Typo in schemes.tex

### DIFF
--- a/schemes.tex
+++ b/schemes.tex
@@ -1287,7 +1287,7 @@ the $R$-module $\Gamma(X, \mathcal{F})$.
 \begin{proof}
 Let $\mathcal{F}$ be a quasi-coherent $\mathcal{O}_X$-module.
 Since every standard open $D(f)$ is quasi-compact we see that
-$X$ is a locally quasi-compact, i.e., every point has a fundamental
+$X$ is locally quasi-compact, i.e., every point has a fundamental
 system of quasi-compact neighbourhoods, see Topology,
 Definition \ref{topology-definition-locally-quasi-compact}.
 Hence by Modules, Lemma \ref{modules-lemma-quasi-coherent-module}


### PR DESCRIPTION
Typo correction at the beginning of the proof of [01IA](https://stacks.math.columbia.edu/tag/01IA).