### PR TITLE
Small wording change in 01ZM about descending relative objects

### DIFF
--- a/limits.tex
+++ b/limits.tex
@@ -2369,7 +2369,7 @@ convince yourself that the result is true than to read this proof.
 \begin{lemma}
 \label{lemma-descend-finite-presentation}
 Let $I$ be a directed set.
-Let $(S_i, f_{ii'})$ be an inverse system of schemes over $I$.
+Let $(S_i, f_{ii'})$ be an inverse system of schemes indexed over $I$.
 Assume
 \begin{enumerate}
 \item the morphisms $f_{ii'} : S_i \to S_{i'}$ are affine,


### PR DESCRIPTION
Let $I$ be a directed set. Let $(S_i,f_{ii}′)$ be an inverse system of schemes **indexed** over $I$. (very tiny edit but before it sounds a little like $I$ is the base scheme)