### PR TITLE
Added statement and proof that (quasi-)separatedness is local on the target

### DIFF
--- a/schemes.tex
+++ b/schemes.tex
@@ -3562,22 +3562,47 @@ Topology, Definition \ref{topology-definition-quasi-compact}.
 \begin{lemma}
 \label{lemma-quasi-compact-affine}
 Let $f : X \to S$ be a morphism of schemes.
-The following are equivalent
+The following are equivalent:
 \begin{enumerate}
 \item $f : X \to S$ is quasi-compact,
-\item the inverse image of every affine open is quasi-compact, and
+\item the inverse image of every affine open is quasi-compact,
+\item there is an open cover $S=\bigcup_{i\in I} U_i$
+such that the restriction $f^{-1}(U_i)\to U_i$
+is quasi-compact for all $i$, and
 \item there exists some affine open covering $S = \bigcup_{i \in I} U_i$
 such that $f^{-1}(U_i)$ is quasi-compact for all $i$.
 \end{enumerate}
 \end{lemma}
 
 \begin{proof}
+(1)$\Rightarrow$(2).
+Affine schemes are quasi-compact,
+see Algebra, Lemma \ref{algebra-lemma-quasi-compact}.
+
+\medskip\noindent
+(2)$\Rightarrow$(1).
+Let $K \subset S$ be any quasi-compact open. Since $S$ has a basis
+of the topology consisting of affine opens we see that $K$ is a finite
+union of affine opens. Hence the inverse image of $K$ is a finite
+union of affine opens. Hence $f$ is quasi-compact.
+
+\medskip\noindent
+(1)$\Rightarrow$(3). Trivial.
+
+\medskip\noindent
+(3)$\Rightarrow$(4).
+For each $i\in I$, take an open affine cover $U_i=\bigcup_{k\in K_i}V_{ik}$,
+so $f^{-1}(V_{ik})$ is quasi-compact.
+The cover $Y=\bigcup_{i\in I}\bigcup_{k\in K_i}V_{ik}$ suffices.
+
+\medskip\noindent
+(4)$\Rightarrow$(1).
 Suppose we are given a covering $S = \bigcup_{i \in I} U_i$ as in (3).
-First, let $U \subset S$ be any affine open. For any $u \in U$
+First, let $U \subset S$ be any quasi-compact open subset. For any $u \in U$
 we can find an index $i(u) \in I$ such that $u \in U_{i(u)}$.
 As standard opens form a basis for the topology on $U_{i(u)}$ we can find
-$W_u \subset U \cap U_{i(u)}$ which is standard open in $U_{i(u)}$.
-By compactness we can find finitely many points $u_1, \ldots, u_n \in U$
+$W_u \subset U \cap U_{i(u)}$ containing $u$ which is standard open in $U_{i(u)}$.
+By quasi-compactness we can find finitely many points $u_1, \ldots, u_n \in U$
 such that $U = \bigcup_{j = 1}^n W_{u_j}$. For each $j$ write
 $f^{-1}U_{i(u_j)} = \bigcup_{k \in K_j} V_{jk}$ as a finite
 union of affine opens. Since $W_{u_j} \subset U_{i(u_j)}$ is a standard
@@ -3585,20 +3610,8 @@ open we see that $f^{-1}(W_{u_j}) \cap V_{jk}$ is a standard
 open of $V_{jk}$, see Algebra, Lemma \ref{algebra-lemma-spec-functorial}.
 Hence $f^{-1}(W_{u_j}) \cap V_{jk}$ is affine, and so
 $f^{-1}(W_{u_j})$ is a finite union of affines. This proves that the
-inverse image of any affine open is a finite union of affine opens.
-
-\medskip\noindent
-Next, assume that the inverse image of every affine open is a finite
-union of affine opens.
-Let $K \subset S$ be any quasi-compact open. Since $S$ has a basis
-of the topology consisting of affine opens we see that $K$ is a finite
-union of affine opens. Hence the inverse image of $K$ is a finite
-union of affine opens. Hence $f$ is quasi-compact.
-
-\medskip\noindent
-Finally, assume that $f$ is quasi-compact. In this case the argument
-of the previous paragraph shows that the inverse image of any affine
-is a finite union of affine opens.
+inverse image of any quasi-compact open is a finite union of affine opens and,
+hence, quasi-compact.
 \end{proof}
 
 \begin{lemma}
@@ -4071,6 +4084,64 @@ $X_1 \times_S X_2$ under $\Delta_{X/S}$ is the scheme
 $\Spec(k[t_1, t_2, t_3, \ldots]) \setminus \{0\}$
 which is not quasi-compact.
 \end{example}
+
+\begin{lemma}
+\label{quasi-separated-local-target}
+\begin{slogan}
+(quasi-)separatedness is local on the target.
+\end{slogan}
+For all morphisms of schemes $f:X\to Y$ and all open covers $Y=\bigcup V_i$,
+we have that $f$ is quasi-separated if and only if
+$f|_{f^{-1}(V_i)}:f^{-1}(V_i)\to V_i$ is quasi-separated, for all $i$.
+The same is true if we substitute ``quasi-separated'' by ``separated.''
+\end{lemma}
+
+\begin{proof}
+Let $\mathcal{P}$ be a property of morphisms of schemes stable
+under pre- and postcompositions with isomorphisms
+(i.e., $g\circ f$ and $f\circ h$ have $\mathcal{P}$
+provided that $f$ has $\mathcal{P}$, for all isos $g,h$
+such that the composites make sense).
+We say that a morphism of schemes $f:X\to Y$ has $\Delta_\mathcal{P}$
+if the diagonal map $\Delta_{X/Y}$ has $\mathcal{P}$.
+(The ``isomorphism-stable'' condition on $\mathcal{P}$ is to guarantee
+that $\Delta_\mathcal{P}$ does not depend on the choice of fibre product.)
+We say that $\mathcal{P}$ is {\it local on the target}
+if for all morphisms of schemes $f:X\to Y$ and all open covers $Y=\bigcup V_i$,
+we have that $f$ has $\mathcal{P}$ if and only if
+$f|_{f^{-1}(V_i)}:f^{-1}(V_i)\to V_i$ has $\mathcal{P}$.
+We shall prove that if $\mathcal{P}$ is local on the target,
+then so is $\Delta_\mathcal{P}$.
+The statement will follow then from this result plus
+Lemmas \ref{lemma-quasi-compact-affine} and
+\ref{lemma-closed-local-target}.
+
+\medskip\noindent
+Let $f:X\to Y$ be a morphism of schemes.
+
+\medskip\noindent
+Suppose first $f$ has $\mathcal{P}$, let $V\subset Y$ be open and call $U=f^{-1}(V)$.
+Note that $U\times_Y U=U\times_V U$ is an open subscheme of $X\times_Y X$
+(Lemma \ref{lemma-open-fibre-product}). Since $\Delta_f$ has $\mathcal{P}$,
+then so does $\Delta_{X/Y}|_{U}:U=\Delta_{X/Y}^{-1}(U\times_V U)\to U\times_V U$.
+But this map is $\Delta_{U/V}$.
+
+\medskip\noindent
+Conversely, suppose there is an open cover $Y=\bigcup_{i\in I}V_i$
+such that $f|_{U_i}:U_i\to V_i$ has $\Delta_\mathcal{P}$ for all $i\in I$,
+where $U_i=f^{-1}(V_i)$, i.e., $\Delta_{U_i/V_i}$ has $\mathcal{P}$.
+But $\Delta_{U_i/V_i}$ can be identified with
+$\Delta_{X/Y}|_{U_i}:U_i
+=\Delta_{X/Y}^{-1}(U_i\times_{V_i}U_i)
+\to U_i\times_{V_i}U_i\subset X\times_Y X$.
+It suffices to argue then that the sets $U_i\times_{V_i}U_i$ cover $X\times_Y X$.
+This follows from the facts
+(i) $U_i\times_{V_i}U_i=p^{-1}(U_i)\cap q^{-1}(U_i)$,
+where $X\xleftarrow{p}X\times_Y X\xrightarrow{q}X$ are the canonical projections
+(Lemma \ref{lemma-open-fibre-product}),
+(ii) $f\circ p=f\circ q$, and
+(iii) the sets $V_i$ cover $Y$.
+\end{proof}
 
 \begin{lemma}
 \label{lemma-where-are-they-equal}


### PR DESCRIPTION
This was originally contained in pull request #168.