### PR TITLE
Added "Pulling back sections" section in modules.tex

### DIFF
--- a/modules.tex
+++ b/modules.tex
@@ -458,7 +458,120 @@ in the proof of Lemma \ref{lemma-generated-by-local-sections}.
 
 
 
+\section{Pulling back sections}
+\label{section-pullback-section}
 
+\begin{lemma}
+\label{lemma-pullback-section}
+Let $f : (X, \mathcal{O}_X) \to (Y, \mathcal{O}_Y)$ be a morphism of
+ringed spaces. Let $\mathcal{G}$ be a sheaf of
+$\mathcal{O}_Y$-modules. Let $V\subset Y$ be an open subset. Let
+$s\in\mathcal{G}(V)$ be a section. Denote $g:f^{-1}(V)\to V$ to the
+restriction of $f$. The following two sections in $f^*G(f^{-1}(V))$
+are the same:
+\begin{enumerate}
+\item The image of $s$ along the unit
+$\mathcal{G}\to f_*f^*\mathcal{G}$ of the adjunction between
+$f_*$ and $f^*$, and
+\item The global section of $g^*(\mathcal{G}|_V)$ associated with
+$\mathcal{O}_{f^{-1}(V)}\cong
+g^*\mathcal{O}_V\to g^*(\mathcal{G}|_V)$,
+where $\mathcal{O}_V\to\mathcal{G}|_V$ is the map associated with $s$
+(see first paragraph of Section \ref{section-sections}).
+\end{enumerate}
+\end{lemma}
+
+\begin{proof}
+Naturality of the unit of the adjunction between $g_*$ and $g^*$ gives a
+commutative diagram
+$$
+\xymatrix{
+\mathcal{O}_V \ar@{->}[r] \ar@{->}[d] & \mathcal{G}|_V \ar@{->}[d] \\
+g_*\mathcal{O}_{f^{-1}(V)}\cong g_*g^*\mathcal{O}_V \ar@{->}[r]
+& g_*g^*(\mathcal{G}|_V)
+}
+$$
+The result follows then from the fact that the restriction of the unit
+$\mathcal{G}\to f_*f^*\mathcal{G}$ of the adjunction between $f_*$ and $f^*$ to $V$
+equals $\mathcal{G}|_V\to g_*g^*(\mathcal{G}|_V)$,
+the unit of the adjunction between $g_*$ and $g^*$.
+\end{proof}
+
+\begin{definition}
+\label{definition-pullback-section}
+Let $f : (X, \mathcal{O}_X) \to (Y, \mathcal{O}_Y)$ be a morphism of
+ringed spaces. Let $\mathcal{G}$ be a sheaf of
+$\mathcal{O}_Y$-modules. Let $V\subset Y$ be an open subset. Let
+$s\in\mathcal{G}(V)$ be a section. The {\it pullback section of $s$
+	along $f$}, denoted $f^*s$, is defined to be the section in
+$f^*\mathcal{G}(f^{-1}(V))$ from Lemma \ref{lemma-pullback-section}.
+\end{definition}
+
+\begin{lemma}
+\label{lemma-pullback-section-germ}
+Let $f : (X, \mathcal{O}_X) \to (Y, \mathcal{O}_Y)$ be a morphism of
+ringed spaces. Let $\mathcal{G}$ be a sheaf of
+$\mathcal{O}_Y$-modules.
+Let $V\subset Y$ be an open subset.
+Let $s\in\mathcal{G}(V)$ be a section.
+Let $x\in f^{-1}(V)$ be a point.
+By means of the isomorphism in
+Sheaves, Lemma \ref{sheaves-lemma-stalk-pullback-modules},
+we can identify $(f^*s)_x=s_{f(x)}\otimes 1$.
+\end{lemma}
+
+\begin{proof}
+Without loss of generality, assume $V=Y$.
+Let $\mathcal{O}_Y\to\mathcal{G}$ be the
+$\mathcal{O}_Y$-linear map sending the global section $1$ to $s$.
+The result follows by studying the map on stalks at
+$x$ induced by $f^*\mathcal{O}_Y\to f^*\mathcal{G}$.
+\end{proof}
+
+\begin{lemma}
+\label{lemma-pullback-section-morphism}
+Let $f : (X, \mathcal{O}_X) \to (Y, \mathcal{O}_Y)$
+be a morphism of ringed spaces.
+Let $\varphi:\mathcal{G}\to\mathcal{G}'$ be a morphism of
+sheaves of $\mathcal{O}_Y$-modules.
+Let $V\subset Y$ be an open subset.
+Let $s\in\mathcal{G}(V)$ be a section.
+Then $f^*(\varphi(s))=(f^*\varphi)(f^*s)$.
+\end{lemma}
+
+\begin{proof}
+This follows from the naturality of the unit, i.e.,
+the following square commutes:
+$$
+\xymatrix{
+\mathcal{G} \ar@{->}[r] \ar@{->}[d] & \mathcal{G}' \ar@{->}[d] \\
+f_*f^*\mathcal{G} \ar@{->}[r] & f_*f^*\mathcal{G}'
+}
+$$
+In the square, if we map $s$ first down then right,
+we get $(f^*\varphi)(f^*s)$. If we map $s$ first right then down,
+we get $f^*(\varphi(s))$.
+\end{proof}
+
+\begin{lemma}
+\label{lemma-pullback-section-functorial}
+Let
+$(X,\mathcal{O}_X)
+\xrightarrow{f}(Y,\mathcal{O}_Y)
+\xrightarrow{g}(Z,\mathcal{O}_Z)$ be morphisms of ringed spaces.
+Let $\mathcal{H}$ be a sheaf of $\mathcal{O}_Z$-modules.
+Let $W\subset Z$ be an open subset.
+Let $t\in\mathcal{G}(W)$ be a section.
+By the means of the isomorphism of functors
+$(g\circ f)^*\cong f^*\circ g^*$
+(Sheaves, Lemma \ref{sheaves-lemma-push-pull-composition-modules}),
+we can identify $(g\circ f)^*t=f^*(g^*t)$.
+\end{lemma}
+
+\begin{proof}
+This follows by the description of the pullback section
+in point (2) of Lemma \ref{lemma-pullback-section}.
+\end{proof}
 
 
 


### PR DESCRIPTION
Defined the pullback of a section of a sheaf of modules along a morphism of ringed spaces. Collected basic functorial properties.

I know this material may very basic, but it's nowhere treated. Despite this, the concept is extensively used in algebraic geometry and in particular in the Stacks Project:
1. In Tag [01CR](https://stacks.math.columbia.edu/tag/01CR), implicitly in the definition of `f* : Γ_*(X,ℒ) → Γ_*(Y,f*ℒ)`.
2. The notation is used without explanation in:
&nbsp;&nbsp; • The statement of Tag [08RU](https://stacks.math.columbia.edu/tag/08RU).
&nbsp;&nbsp; • The proof of Tag [0H79](https://stacks.math.columbia.edu/tag/0H79).

(The list might not be exhaustive, it's only the instances I came across so far.) 