### PR TITLE
Fix trivial typos in tags 07VC and 07BQ in section 00S0. 

### DIFF
--- a/algebra.tex
+++ b/algebra.tex
@@ -35477,7 +35477,7 @@ A \ar[r] \ar[u] & B \ar[u]
 }
 $$
 Write $J = \Ker(B[C] \to C)$. An explicit homotopy is given by the map
-$\Omega_{A[B]/A} \otimes_A B \to J/J^2$ which maps the basis element
+$\Omega_{A[B]/A} \otimes_{A[B]} B \to J/J^2$ which maps the basis element
 $\text{d}[b]$ to the class of $[\phi(b)] - b$ in $J/J^2$.
 \end{remark}
 
@@ -35534,17 +35534,17 @@ since $R \to R'$ is flat.
 
 \begin{lemma}
 \label{lemma-colimits-NL}
-Let $R_i \to S_i$ be a system of ring maps over the directed set $I$.
-Set $R = \colim R_i$ and $S = \colim S_i$.
-Then $\NL_{S/R} = \colim \NL_{S_i/R_i}$.
+Let $R_\lambda \to S_\lambda$ be a system of ring maps over the directed set $\Lambda$.
+Set $R = \colim R_\lambda$ and $S = \colim S_\lambda$.
+Then $\NL_{S/R} = \colim \NL_{S_\lambda/R_\lambda}$.
 \end{lemma}
 
 \begin{proof}
 Recall that $\NL_{S/R}$ is the complex
 $I/I^2 \to \bigoplus_{s \in S} S\text{d}[s]$ where $I \subset R[S]$
 is the kernel of the canonical presentation $R[S] \to S$.
-Now it is clear that $R[S] = \colim R_i[S_i]$ and similarly
-that $I = \colim I_i$ where $I_i = \Ker(R_i[S_i] \to S_i)$.
+Now it is clear that $R[S] = \colim R_\lambda[S_\lambda]$ and similarly
+that $I = \colim I_\lambda$ where $I_\lambda = \Ker(R_\lambda[S_\lambda] \to S_\lambda)$.
 Hence the lemma is clear.
 \end{proof}
 


### PR DESCRIPTION
I fixed some typos in tags 07VC and 07BQ. 
In 07VC, the last tensor product was over $A$, however this should be over $A[B]$. 
In 07BQ, the set of direct system and the kernel of $R[S] \to S$ were both $I$. I changed the notation of the former set into $\Lambda$. 